### PR TITLE
Sets minimum supported Rust version to 1.50.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["CalDAV", "client", "WebDAV", "todo", "iCloud"]
 categories = ["network-programming", "web-programming::http-client"]
+metadata = { msrv = "1.50.0" }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Sets the MSRV so that we can avoid inadvertently increasing it in the future.

It was determined using the cargo-msrv tool.