### PR TITLE
Error reform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -456,6 +456,7 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "url",
  "uuid",
@@ -664,7 +665,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -708,11 +709,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -726,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -921,7 +922,7 @@ checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -981,6 +982,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,22 +1017,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1072,7 +1084,7 @@ checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.85",
 ]
 
 [[package]]
@@ -1136,6 +1148,12 @@ name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -1223,7 +1241,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -1257,7 +1275,7 @@ checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "chrono",
  "csscolorparser",
  "env_logger",
+ "http",
  "ical-daladim",
  "ics",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ chrono = { version = "0.4", features = ["serde"] }
 csscolorparser = { version = "0.5", features = ["serde"] }
 once_cell = "1.8"
 itertools = "0.10"
+thiserror = "1.0.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0"
 async-trait = "0.1"
 uuid = { version = "0.8", features = ["v4"] }
 sanitize-filename = "0.3"
+http = "0.2.6"
 ical-daladim = { version = "0.8", features = ["serde-derive"] }
 ics = "0.5"
 chrono = { version = "0.4", features = ["serde"] }

--- a/examples/provider-sync.rs
+++ b/examples/provider-sync.rs
@@ -1,24 +1,23 @@
 //! This is an example of how kitchen-fridge can be used
 
-use chrono::{Utc};
+use chrono::Utc;
 use url::Url;
 
-use kitchen_fridge::traits::CalDavSource;
 use kitchen_fridge::calendar::SupportedComponents;
-use kitchen_fridge::Item;
-use kitchen_fridge::Task;
 use kitchen_fridge::task::CompletionStatus;
-use kitchen_fridge::CalDavProvider;
 use kitchen_fridge::traits::BaseCalendar;
+use kitchen_fridge::traits::CalDavSource;
 use kitchen_fridge::traits::CompleteCalendar;
 use kitchen_fridge::utils::pause;
+use kitchen_fridge::CalDavProvider;
+use kitchen_fridge::Item;
+use kitchen_fridge::Task;
 
 mod shared;
 use shared::initial_sync;
-use shared::{URL, USERNAME, EXAMPLE_EXISTING_CALENDAR_URL, EXAMPLE_CREATED_CALENDAR_URL};
+use shared::{EXAMPLE_CREATED_CALENDAR_URL, EXAMPLE_EXISTING_CALENDAR_URL, URL, USERNAME};
 
 const CACHE_FOLDER: &str = "test_cache/provider_sync";
-
 
 #[tokio::main]
 async fn main() {
@@ -26,13 +25,21 @@ async fn main() {
 
     println!("This example show how to sync a remote server with a local cache, using a Provider.");
     println!("Make sure you have edited the constants in the 'shared.rs' file to include correct URLs and credentials.");
-    println!("You can also set the RUST_LOG environment variable to display more info about the sync.");
+    println!(
+        "You can also set the RUST_LOG environment variable to display more info about the sync."
+    );
     println!("");
     println!("This will use the following settings:");
     println!("  * URL = {}", URL);
     println!("  * USERNAME = {}", USERNAME);
-    println!("  * EXAMPLE_EXISTING_CALENDAR_URL = {}", EXAMPLE_EXISTING_CALENDAR_URL);
-    println!("  * EXAMPLE_CREATED_CALENDAR_URL = {}", EXAMPLE_CREATED_CALENDAR_URL);
+    println!(
+        "  * EXAMPLE_EXISTING_CALENDAR_URL = {}",
+        EXAMPLE_EXISTING_CALENDAR_URL
+    );
+    println!(
+        "  * EXAMPLE_CREATED_CALENDAR_URL = {}",
+        EXAMPLE_CREATED_CALENDAR_URL
+    );
     pause();
 
     let mut provider = initial_sync(CACHE_FOLDER).await;
@@ -47,32 +54,56 @@ async fn add_items_and_sync_again(provider: &mut CalDavProvider) {
     // Create a new calendar...
     let new_calendar_url: Url = EXAMPLE_CREATED_CALENDAR_URL.parse().unwrap();
     let new_calendar_name = "A brave new calendar".to_string();
-    if let Err(_err) = provider.local_mut()
-        .create_calendar(new_calendar_url.clone(), new_calendar_name.clone(), SupportedComponents::TODO, Some("#ff8000".parse().unwrap()))
-        .await {
-            println!("Unable to add calendar, maybe it exists already. We're not adding it after all.");
+    if let Err(_err) = provider
+        .local_mut()
+        .create_calendar(
+            new_calendar_url.clone(),
+            new_calendar_name.clone(),
+            SupportedComponents::TODO,
+            Some("#ff8000".parse().unwrap()),
+        )
+        .await
+    {
+        println!("Unable to add calendar, maybe it exists already. We're not adding it after all.");
     }
 
     // ...and add a task in it
     let new_name = "This is a new task in a new calendar";
     let new_task = Task::new(String::from(new_name), true, &new_calendar_url);
-    provider.local().get_calendar(&new_calendar_url).await.unwrap()
-        .lock().unwrap().add_item(Item::Task(new_task)).await.unwrap();
-
+    provider
+        .local()
+        .get_calendar(&new_calendar_url)
+        .await
+        .unwrap()
+        .lock()
+        .unwrap()
+        .add_item(Item::Task(new_task))
+        .await
+        .unwrap();
 
     // Also create a task in a previously existing calendar
     let changed_calendar_url: Url = EXAMPLE_EXISTING_CALENDAR_URL.parse().unwrap();
     let new_task_name = "This is a new task we're adding as an example, with ÜTF-8 characters";
     let new_task = Task::new(String::from(new_task_name), false, &changed_calendar_url);
     let new_url = new_task.url().clone();
-    provider.local().get_calendar(&changed_calendar_url).await.unwrap()
-        .lock().unwrap().add_item(Item::Task(new_task)).await.unwrap();
-
+    provider
+        .local()
+        .get_calendar(&changed_calendar_url)
+        .await
+        .unwrap()
+        .lock()
+        .unwrap()
+        .add_item(Item::Task(new_task))
+        .await
+        .unwrap();
 
     if provider.sync().await == false {
         log::warn!("Sync did not complete, see the previous log lines for more info. You can safely start a new sync. The new task may not have been synced.");
     } else {
-        println!("Done syncing the new task '{}' and the new calendar '{}'", new_task_name, new_calendar_name);
+        println!(
+            "Done syncing the new task '{}' and the new calendar '{}'",
+            new_task_name, new_calendar_name
+        );
     }
     provider.local().save_to_folder().unwrap();
 
@@ -82,14 +113,22 @@ async fn add_items_and_sync_again(provider: &mut CalDavProvider) {
 async fn complete_item_and_sync_again(
     provider: &mut CalDavProvider,
     changed_calendar_url: &Url,
-    url_to_complete: &Url)
-{
+    url_to_complete: &Url,
+) {
     println!("\nNow, we'll mark this last task as completed, and run the sync again.");
     pause();
 
     let completion_status = CompletionStatus::Completed(Some(Utc::now()));
-    provider.local().get_calendar(changed_calendar_url).await.unwrap()
-        .lock().unwrap().get_item_by_url_mut(url_to_complete).await.unwrap()
+    provider
+        .local()
+        .get_calendar(changed_calendar_url)
+        .await
+        .unwrap()
+        .lock()
+        .unwrap()
+        .get_item_by_url_mut(url_to_complete)
+        .await
+        .unwrap()
         .unwrap_task_mut()
         .set_completion_status(completion_status);
 
@@ -106,15 +145,22 @@ async fn complete_item_and_sync_again(
 async fn remove_items_and_sync_again(
     provider: &mut CalDavProvider,
     changed_calendar_url: &Url,
-    id_to_remove: &Url)
-{
+    id_to_remove: &Url,
+) {
     println!("\nNow, we'll delete this last task, and run the sync again.");
     pause();
 
     // Remove the task we had created
-    provider.local().get_calendar(changed_calendar_url).await.unwrap()
-        .lock().unwrap()
-        .mark_for_deletion(id_to_remove).await.unwrap();
+    provider
+        .local()
+        .get_calendar(changed_calendar_url)
+        .await
+        .unwrap()
+        .lock()
+        .unwrap()
+        .mark_for_deletion(id_to_remove)
+        .await
+        .unwrap();
 
     if provider.sync().await == false {
         log::warn!("Sync did not complete, see the previous log lines for more info. You can safely start a new sync. The new task may not have been synced.");

--- a/examples/provider-sync.rs
+++ b/examples/provider-sync.rs
@@ -28,7 +28,7 @@ async fn main() {
     println!(
         "You can also set the RUST_LOG environment variable to display more info about the sync."
     );
-    println!("");
+    println!();
     println!("This will use the following settings:");
     println!("  * URL = {}", URL);
     println!("  * USERNAME = {}", USERNAME);
@@ -97,7 +97,7 @@ async fn add_items_and_sync_again(provider: &mut CalDavProvider) {
         .await
         .unwrap();
 
-    if provider.sync().await == false {
+    if !(provider.sync().await) {
         log::warn!("Sync did not complete, see the previous log lines for more info. You can safely start a new sync. The new task may not have been synced.");
     } else {
         println!(
@@ -132,7 +132,7 @@ async fn complete_item_and_sync_again(
         .unwrap_task_mut()
         .set_completion_status(completion_status);
 
-    if provider.sync().await == false {
+    if !(provider.sync().await) {
         log::warn!("Sync did not complete, see the previous log lines for more info. You can safely start a new sync. The new task may not have been synced.");
     } else {
         println!("Done syncing the completed task");
@@ -162,7 +162,7 @@ async fn remove_items_and_sync_again(
         .await
         .unwrap();
 
-    if provider.sync().await == false {
+    if !(provider.sync().await) {
         log::warn!("Sync did not complete, see the previous log lines for more info. You can safely start a new sync. The new task may not have been synced.");
     } else {
         println!("Done syncing the deleted task");

--- a/examples/shared.rs
+++ b/examples/shared.rs
@@ -1,23 +1,23 @@
 use std::path::Path;
 
+use kitchen_fridge::cache::Cache;
 use kitchen_fridge::client::Client;
 use kitchen_fridge::traits::CalDavSource;
 use kitchen_fridge::CalDavProvider;
-use kitchen_fridge::cache::Cache;
-
 
 // TODO: change these values with yours
 pub const URL: &str = "https://my.server.com/remote.php/dav/files/john";
 pub const USERNAME: &str = "username";
 pub const PASSWORD: &str = "secret_password";
 
-pub const EXAMPLE_EXISTING_CALENDAR_URL: &str = "https://my.server.com/remote.php/dav/calendars/john/a_calendar_name/";
-pub const EXAMPLE_CREATED_CALENDAR_URL: &str =  "https://my.server.com/remote.php/dav/calendars/john/a_calendar_that_we_have_created/";
+pub const EXAMPLE_EXISTING_CALENDAR_URL: &str =
+    "https://my.server.com/remote.php/dav/calendars/john/a_calendar_name/";
+pub const EXAMPLE_CREATED_CALENDAR_URL: &str =
+    "https://my.server.com/remote.php/dav/calendars/john/a_calendar_that_we_have_created/";
 
 fn main() {
     panic!("This file is not supposed to be executed");
 }
-
 
 /// Initializes a Provider, and run an initial sync from the server
 pub async fn initial_sync(cache_folder: &str) -> CalDavProvider {
@@ -33,13 +33,14 @@ pub async fn initial_sync(cache_folder: &str) -> CalDavProvider {
     };
     let mut provider = CalDavProvider::new(client, cache);
 
-
     let cals = provider.local().get_calendars().await.unwrap();
     println!("---- Local items, before sync -----");
     kitchen_fridge::utils::print_calendar_list(&cals).await;
 
     println!("Starting a sync...");
-    println!("Depending on your RUST_LOG value, you may see more or less details about the progress.");
+    println!(
+        "Depending on your RUST_LOG value, you may see more or less details about the progress."
+    );
     // Note that we could use sync_with_feedback() to have better and formatted feedback
     if provider.sync().await == false {
         log::warn!("Sync did not complete, see the previous log lines for more info. You can safely start a new sync.");

--- a/examples/shared.rs
+++ b/examples/shared.rs
@@ -24,11 +24,11 @@ pub async fn initial_sync(cache_folder: &str) -> CalDavProvider {
     let cache_path = Path::new(cache_folder);
 
     let client = Client::new(URL, USERNAME, PASSWORD).unwrap();
-    let cache = match Cache::from_folder(&cache_path) {
+    let cache = match Cache::from_folder(cache_path) {
         Ok(cache) => cache,
         Err(err) => {
             log::warn!("Invalid cache file: {}. Using a default cache", err);
-            Cache::new(&cache_path)
+            Cache::new(cache_path)
         }
     };
     let mut provider = CalDavProvider::new(client, cache);
@@ -42,7 +42,7 @@ pub async fn initial_sync(cache_folder: &str) -> CalDavProvider {
         "Depending on your RUST_LOG value, you may see more or less details about the progress."
     );
     // Note that we could use sync_with_feedback() to have better and formatted feedback
-    if provider.sync().await == false {
+    if !(provider.sync().await) {
         log::warn!("Sync did not complete, see the previous log lines for more info. You can safely start a new sync.");
     }
     provider.local().save_to_folder().unwrap();

--- a/examples/shared.rs
+++ b/examples/shared.rs
@@ -10,9 +10,9 @@ pub const URL: &str = "https://my.server.com/remote.php/dav/files/john";
 pub const USERNAME: &str = "username";
 pub const PASSWORD: &str = "secret_password";
 
-pub const EXAMPLE_EXISTING_CALENDAR_URL: &str =
+pub const _EXAMPLE_EXISTING_CALENDAR_URL: &str =
     "https://my.server.com/remote.php/dav/calendars/john/a_calendar_name/";
-pub const EXAMPLE_CREATED_CALENDAR_URL: &str =
+pub const _EXAMPLE_CREATED_CALENDAR_URL: &str =
     "https://my.server.com/remote.php/dav/calendars/john/a_calendar_that_we_have_created/";
 
 fn main() {

--- a/examples/shared.rs
+++ b/examples/shared.rs
@@ -10,9 +10,9 @@ pub const URL: &str = "https://my.server.com/remote.php/dav/files/john";
 pub const USERNAME: &str = "username";
 pub const PASSWORD: &str = "secret_password";
 
-pub const _EXAMPLE_EXISTING_CALENDAR_URL: &str =
+pub const EXAMPLE_EXISTING_CALENDAR_URL: &str =
     "https://my.server.com/remote.php/dav/calendars/john/a_calendar_name/";
-pub const _EXAMPLE_CREATED_CALENDAR_URL: &str =
+pub const EXAMPLE_CREATED_CALENDAR_URL: &str =
     "https://my.server.com/remote.php/dav/calendars/john/a_calendar_that_we_have_created/";
 
 fn main() {

--- a/examples/toggle-completions.rs
+++ b/examples/toggle-completions.rs
@@ -7,8 +7,8 @@ use chrono::Utc;
 
 use kitchen_fridge::item::Item;
 use kitchen_fridge::task::CompletionStatus;
-use kitchen_fridge::CalDavProvider;
 use kitchen_fridge::utils::pause;
+use kitchen_fridge::CalDavProvider;
 
 mod shared;
 use shared::initial_sync;
@@ -22,7 +22,9 @@ async fn main() {
 
     println!("This example show how to sync a remote server with a local cache, using a Provider.");
     println!("Make sure you have edited the constants in the 'shared.rs' file to include correct URLs and credentials.");
-    println!("You can also set the RUST_LOG environment variable to display more info about the sync.");
+    println!(
+        "You can also set the RUST_LOG environment variable to display more info about the sync."
+    );
     println!("");
     println!("This will use the following settings:");
     println!("  * URL = {}", URL);
@@ -31,10 +33,14 @@ async fn main() {
 
     let mut provider = initial_sync(CACHE_FOLDER).await;
 
-    toggle_all_tasks_and_sync_again(&mut provider).await.unwrap();
+    toggle_all_tasks_and_sync_again(&mut provider)
+        .await
+        .unwrap();
 }
 
-async fn toggle_all_tasks_and_sync_again(provider: &mut CalDavProvider) -> Result<(), Box<dyn Error>> {
+async fn toggle_all_tasks_and_sync_again(
+    provider: &mut CalDavProvider,
+) -> Result<(), Box<dyn Error>> {
     let mut n_toggled = 0;
 
     for (_url, cal) in provider.local().get_calendars_sync()?.iter() {
@@ -42,14 +48,15 @@ async fn toggle_all_tasks_and_sync_again(provider: &mut CalDavProvider) -> Resul
             match item {
                 Item::Task(task) => {
                     match task.completed() {
-                        false => task.set_completion_status(CompletionStatus::Completed(Some(Utc::now()))),
+                        false => task
+                            .set_completion_status(CompletionStatus::Completed(Some(Utc::now()))),
                         true => task.set_completion_status(CompletionStatus::Uncompleted),
                     };
                     n_toggled += 1;
                 }
                 Item::Event(_) => {
                     // Not doing anything with calendar events
-                },
+                }
             }
         }
     }

--- a/examples/toggle-completions.rs
+++ b/examples/toggle-completions.rs
@@ -44,7 +44,7 @@ async fn toggle_all_tasks_and_sync_again(
     let mut n_toggled = 0;
 
     for (_url, cal) in provider.local().get_calendars_sync()?.iter() {
-        for (_url, item) in cal.lock().unwrap().get_items_mut_sync()?.iter_mut() {
+        for (_url, item) in cal.lock().unwrap().get_items_mut_sync().iter_mut() {
             match item {
                 Item::Task(task) => {
                     match task.completed() {

--- a/examples/toggle-completions.rs
+++ b/examples/toggle-completions.rs
@@ -25,7 +25,7 @@ async fn main() {
     println!(
         "You can also set the RUST_LOG environment variable to display more info about the sync."
     );
-    println!("");
+    println!();
     println!("This will use the following settings:");
     println!("  * URL = {}", URL);
     println!("  * USERNAME = {}", USERNAME);

--- a/examples/toggle-completions.rs
+++ b/examples/toggle-completions.rs
@@ -1,10 +1,9 @@
 //! This is an example of how kitchen-fridge can be used.
 //! This binary simply toggles all completion statuses of the tasks it finds.
 
-use std::error::Error;
-
 use chrono::Utc;
 
+use kitchen_fridge::error::KFResult;
 use kitchen_fridge::item::Item;
 use kitchen_fridge::task::CompletionStatus;
 use kitchen_fridge::utils::pause;
@@ -38,9 +37,7 @@ async fn main() {
         .unwrap();
 }
 
-async fn toggle_all_tasks_and_sync_again(
-    provider: &mut CalDavProvider,
-) -> Result<(), Box<dyn Error>> {
+async fn toggle_all_tasks_and_sync_again(provider: &mut CalDavProvider) -> KFResult<()> {
     let mut n_toggled = 0;
 
     for (_url, cal) in provider.local().get_calendars_sync()?.iter() {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -54,7 +54,7 @@ impl Cache {
 
     /// Get the path to the cache folder
     pub fn cache_folder() -> PathBuf {
-        return PathBuf::from(String::from("~/.config/my-tasks/cache/"));
+        PathBuf::from(String::from("~/.config/my-tasks/cache/"))
     }
 
     /// Initialize a cache from the content of a valid backing folder if it exists.
@@ -108,7 +108,7 @@ impl Cache {
     }
 
     fn load_calendar(path: &Path) -> Result<CachedCalendar, Box<dyn Error>> {
-        let file = std::fs::File::open(&path)?;
+        let file = std::fs::File::open(path)?;
         Ok(serde_json::from_reader(file)?)
     }
 
@@ -158,7 +158,7 @@ impl Cache {
         let calendars_l = self.get_calendars().await?;
         let calendars_r = other.get_calendars().await?;
 
-        if crate::utils::keys_are_the_same(&calendars_l, &calendars_r) == false {
+        if !crate::utils::keys_are_the_same(&calendars_l, &calendars_r) {
             log::debug!("Different keys for calendars");
             return Ok(false);
         }
@@ -172,7 +172,7 @@ impl Cache {
             };
 
             // TODO: check calendars have the same names/ID/whatever
-            if cal_l.has_same_observable_content_as(&cal_r).await? == false {
+            if !(cal_l.has_same_observable_content_as(&cal_r).await?) {
                 log::debug!("Different calendars");
                 return Ok(false);
             }
@@ -212,7 +212,7 @@ impl Cache {
 
     /// The non-async version of [`crate::traits::CalDavSource::get_calendar`]
     pub fn get_calendar_sync(&self, url: &Url) -> Option<Arc<Mutex<CachedCalendar>>> {
-        self.data.calendars.get(url).map(|arc| arc.clone())
+        self.data.calendars.get(url).cloned()
     }
 }
 
@@ -270,7 +270,7 @@ mod tests {
     use url::Url;
 
     async fn populate_cache(cache_path: &Path) -> Cache {
-        let mut cache = Cache::new(&cache_path);
+        let mut cache = Cache::new(cache_path);
 
         let _shopping_list = cache
             .create_calendar(
@@ -329,7 +329,7 @@ mod tests {
         assert_eq!(cache.backing_folder, retrieved_cache.backing_folder);
         let test = cache.has_same_observable_content_as(&retrieved_cache).await;
         println!("Equal? {:?}", test);
-        assert_eq!(test.unwrap(), true);
+        assert!(test.unwrap());
     }
 
     #[tokio::test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -247,7 +247,7 @@ impl CalDavSource<CachedCalendar> for Cache {
         name: String,
         supported_components: SupportedComponents,
         color: Option<Color>,
-    ) -> Result<Arc<Mutex<CachedCalendar>>, Box<dyn Error>> {
+    ) -> Result<Arc<Mutex<CachedCalendar>>, KFError> {
         log::debug!("Inserting local calendar {}", url);
         #[cfg(feature = "local_calendar_mocks_remote_calendars")]
         self.mock_behaviour
@@ -269,8 +269,7 @@ impl CalDavSource<CachedCalendar> for Cache {
                 type_: ItemType::Calendar,
                 detail: "Attempt to insert calendar failed".into(),
                 url,
-            }
-            .into()),
+            }),
             None => Ok(arc),
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -211,7 +211,7 @@ impl Drop for Cache {
 
 impl Cache {
     /// The non-async version of [`crate::traits::CalDavSource::get_calendars`]
-    pub fn get_calendars_sync(&self) -> Result<HashMap<Url, Arc<Mutex<CachedCalendar>>>, KFError> {
+    pub fn get_calendars_sync(&self) -> KFResult<HashMap<Url, Arc<Mutex<CachedCalendar>>>> {
         #[cfg(feature = "local_calendar_mocks_remote_calendars")]
         self.mock_behaviour
             .as_ref()
@@ -233,7 +233,7 @@ impl Cache {
 
 #[async_trait]
 impl CalDavSource<CachedCalendar> for Cache {
-    async fn get_calendars(&self) -> Result<HashMap<Url, Arc<Mutex<CachedCalendar>>>, KFError> {
+    async fn get_calendars(&self) -> KFResult<HashMap<Url, Arc<Mutex<CachedCalendar>>>> {
         self.get_calendars_sync()
     }
 
@@ -247,7 +247,7 @@ impl CalDavSource<CachedCalendar> for Cache {
         name: String,
         supported_components: SupportedComponents,
         color: Option<Color>,
-    ) -> Result<Arc<Mutex<CachedCalendar>>, KFError> {
+    ) -> KFResult<Arc<Mutex<CachedCalendar>>> {
         log::debug!("Inserting local calendar {}", url);
         #[cfg(feature = "local_calendar_mocks_remote_calendars")]
         self.mock_behaviour

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,6 @@
 //! This module provides a local cache for CalDAV data
 
 use std::collections::HashMap;
-use std::error::Error;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::path::PathBuf;

--- a/src/calendar/cached_calendar.rs
+++ b/src/calendar/cached_calendar.rs
@@ -238,6 +238,10 @@ impl CachedCalendar {
             Some(_) => Ok(()),
         }
     }
+
+    pub fn set_name<S: ToString>(&mut self, name: S) {
+        self.name = name.to_string();
+    }
 }
 
 #[async_trait]

--- a/src/calendar/cached_calendar.rs
+++ b/src/calendar/cached_calendar.rs
@@ -356,7 +356,7 @@ impl DavCalendar for CachedCalendar {
         Ok(result)
     }
 
-    async fn get_item_by_url(&self, url: &Url) -> Result<Option<Item>, Box<dyn Error>> {
+    async fn get_item_by_url(&self, url: &Url) -> KFResult<Option<Item>> {
         #[cfg(feature = "local_calendar_mocks_remote_calendars")]
         self.mock_behaviour
             .as_ref()

--- a/src/calendar/cached_calendar.rs
+++ b/src/calendar/cached_calendar.rs
@@ -334,7 +334,7 @@ impl DavCalendar for CachedCalendar {
         )
     }
 
-    async fn get_item_version_tags(&self) -> Result<HashMap<Url, VersionTag>, Box<dyn Error>> {
+    async fn get_item_version_tags(&self) -> KFResult<HashMap<Url, VersionTag>> {
         #[cfg(feature = "local_calendar_mocks_remote_calendars")]
         self.mock_behaviour
             .as_ref()

--- a/src/calendar/cached_calendar.rs
+++ b/src/calendar/cached_calendar.rs
@@ -159,8 +159,7 @@ impl CachedCalendar {
                 type_: item.type_(),
                 detail: format!("Item {:?} cannot be added", item.url()),
                 url: item.url().clone(),
-            }
-            .into());
+            });
         }
         #[cfg(not(feature = "local_calendar_mocks_remote_calendars"))]
         return Ok(self.regular_add_or_update_item(item));
@@ -176,8 +175,7 @@ impl CachedCalendar {
                 type_: Some(item.type_()),
                 detail: "Item cannot be updated".into(),
                 url: item.url().clone(),
-            }
-            .into());
+            });
         }
         #[cfg(not(feature = "local_calendar_mocks_remote_calendars"))]
         return Ok(self.regular_add_or_update_item(item));
@@ -193,8 +191,7 @@ impl CachedCalendar {
                 type_: None,
                 detail: "Can't mark item for deletion".into(),
                 url: item_url.clone(),
-            }
-            .into()),
+            }),
             Some(item) => {
                 match item.sync_status() {
                     SyncStatus::Synced(prev_ss) => {
@@ -226,8 +223,7 @@ impl CachedCalendar {
                 type_: None,
                 detail: "Can't immediately delete item".into(),
                 url: item_url.clone(),
-            }
-            .into()),
+            }),
             Some(_) => Ok(()),
         }
     }

--- a/src/calendar/cached_calendar.rs
+++ b/src/calendar/cached_calendar.rs
@@ -106,7 +106,7 @@ impl CachedCalendar {
         let items_l = self.get_items().await?;
         let items_r = other.get_items().await?;
 
-        if crate::utils::keys_are_the_same(&items_l, &items_r) == false {
+        if !crate::utils::keys_are_the_same(&items_l, &items_r) {
             log::debug!("Different keys for items");
             return Ok(false);
         }
@@ -115,7 +115,7 @@ impl CachedCalendar {
                 Some(c) => c,
                 None => return Err("should not happen, we've just tested keys are the same".into()),
             };
-            if item_l.has_same_observable_content_as(&item_r) == false {
+            if !item_l.has_same_observable_content_as(item_r) {
                 log::debug!("Different items for URL {}:", url_l);
                 log::debug!("{:#?}", item_l);
                 log::debug!("{:#?}", item_r);
@@ -128,7 +128,7 @@ impl CachedCalendar {
 
     /// The non-async version of [`Self::get_item_urls`]
     pub fn get_item_urls_sync(&self) -> Result<HashSet<Url>, Box<dyn Error>> {
-        Ok(self.items.iter().map(|(url, _)| url.clone()).collect())
+        Ok(self.items.keys().cloned().collect())
     }
 
     /// The non-async version of [`Self::get_items`]
@@ -173,7 +173,7 @@ impl CachedCalendar {
 
     /// The non-async version of [`Self::update_item`]
     pub fn update_item_sync(&mut self, item: Item) -> Result<SyncStatus, Box<dyn Error>> {
-        if self.items.contains_key(item.url()) == false {
+        if !self.items.contains_key(item.url()) {
             return Err(format!(
                 "Item {:?} cannot be updated, it does not already exist",
                 item.url()

--- a/src/calendar/cached_calendar.rs
+++ b/src/calendar/cached_calendar.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
 
 use async_trait::async_trait;
 use csscolorparser::Color;
@@ -365,7 +364,7 @@ impl DavCalendar for CachedCalendar {
         Ok(self.items.get(url).cloned())
     }
 
-    async fn get_items_by_url(&self, urls: &[Url]) -> Result<Vec<Option<Item>>, Box<dyn Error>> {
+    async fn get_items_by_url(&self, urls: &[Url]) -> KFResult<Vec<Option<Item>>> {
         let mut v = Vec::new();
         for url in urls {
             v.push(DavCalendar::get_item_by_url(self, url).await?);

--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -22,13 +22,22 @@ bitflags! {
 
 impl SupportedComponents {
     pub fn to_xml_string(&self) -> String {
-        format!(r#"
+        format!(
+            r#"
             <B:supported-calendar-component-set>
                 {} {}
             </B:supported-calendar-component-set>
             "#,
-            if self.contains(Self::EVENT) { "<B:comp name=\"VEVENT\"/>" } else { "" },
-            if self.contains(Self::TODO)  { "<B:comp name=\"VTODO\"/>"  } else { "" },
+            if self.contains(Self::EVENT) {
+                "<B:comp name=\"VEVENT\"/>"
+            } else {
+                ""
+            },
+            if self.contains(Self::TODO) {
+                "<B:comp name=\"VTODO\"/>"
+            } else {
+                ""
+            },
         )
     }
 }
@@ -49,16 +58,18 @@ impl TryFrom<minidom::Element> for SupportedComponents {
                 Some("VEVENT") => flags.insert(Self::EVENT),
                 Some("VTODO") => flags.insert(Self::TODO),
                 Some(other) => {
-                    log::warn!("Unimplemented supported component type: {:?}. Ignoring it", other);
-                    continue
-                },
+                    log::warn!(
+                        "Unimplemented supported component type: {:?}. Ignoring it",
+                        other
+                    );
+                    continue;
+                }
             };
         }
 
         Ok(flags)
     }
 }
-
 
 /// Flags to tell which events should be retrieved
 pub enum SearchFilter {

--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -4,7 +4,6 @@ pub mod cached_calendar;
 pub mod remote_calendar;
 
 use std::convert::TryFrom;
-use std::error::Error;
 
 use serde::{Deserialize, Serialize};
 
@@ -51,7 +50,7 @@ impl SupportedComponents {
 }
 
 impl TryFrom<minidom::Element> for SupportedComponents {
-    type Error = Box<dyn Error>;
+    type Error = SupportedComponentsError;
 
     /// Create an instance from an XML <supported-calendar-component-set> element
     fn try_from(element: minidom::Element) -> Result<Self, Self::Error> {
@@ -59,8 +58,7 @@ impl TryFrom<minidom::Element> for SupportedComponents {
             return Err(
                 SupportedComponentsError::ElementMustBeSupportedCalendarComponent {
                     element_name: element.name().to_string(),
-                }
-                .into(),
+                },
             );
         }
 

--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -10,6 +10,14 @@ use serde::{Deserialize, Serialize};
 
 use bitflags::bitflags;
 
+#[derive(thiserror::Error, Debug)]
+pub enum SupportedComponentsError {
+    #[error(
+        "Element must be a <supported-calendar-component-set> but got <{element_name}> instead"
+    )]
+    ElementMustBeSupportedCalendarComponent { element_name: String },
+}
+
 bitflags! {
     #[derive(Serialize, Deserialize)]
     pub struct SupportedComponents: u8 {
@@ -48,7 +56,12 @@ impl TryFrom<minidom::Element> for SupportedComponents {
     /// Create an instance from an XML <supported-calendar-component-set> element
     fn try_from(element: minidom::Element) -> Result<Self, Self::Error> {
         if element.name() != "supported-calendar-component-set" {
-            return Err("Element must be a <supported-calendar-component-set>".into());
+            return Err(
+                SupportedComponentsError::ElementMustBeSupportedCalendarComponent {
+                    element_name: element.name().to_string(),
+                }
+                .into(),
+            );
         }
 
         let mut flags = Self::empty();

--- a/src/calendar/remote_calendar.rs
+++ b/src/calendar/remote_calendar.rs
@@ -93,7 +93,7 @@ impl BaseCalendar for RemoteCalendar {
     }
 
     async fn add_item(&mut self, item: Item) -> KFResult<SyncStatus> {
-        let ical_text = crate::ical::build_from(&item)?;
+        let ical_text = crate::ical::build_from(&item);
 
         let response = reqwest::Client::new()
             .put(item.url().clone())
@@ -114,8 +114,7 @@ impl BaseCalendar for RemoteCalendar {
             return Err(KFError::UnexpectedHTTPStatusCode {
                 expected: HttpStatusConstraint::Success,
                 got: response.status(),
-            }
-            .into());
+            });
         }
 
         let reply_hdrs = response.headers();
@@ -149,7 +148,7 @@ impl BaseCalendar for RemoteCalendar {
             SyncStatus::LocallyModified(etag) => etag,
             SyncStatus::LocallyDeleted(etag) => etag,
         };
-        let ical_text = crate::ical::build_from(&item)?;
+        let ical_text = crate::ical::build_from(&item);
 
         let request = reqwest::Client::new()
             .put(item.url().clone())
@@ -170,8 +169,7 @@ impl BaseCalendar for RemoteCalendar {
             return Err(KFError::UnexpectedHTTPStatusCode {
                 expected: HttpStatusConstraint::Success,
                 got: request.status(),
-            }
-            .into());
+            });
         }
 
         let reply_hdrs = request.headers();

--- a/src/calendar/remote_calendar.rs
+++ b/src/calendar/remote_calendar.rs
@@ -271,8 +271,7 @@ impl DavCalendar for RemoteCalendar {
             return Err(KFError::UnexpectedHTTPStatusCode {
                 expected: HttpStatusConstraint::Success,
                 got: res.status(),
-            }
-            .into());
+            });
         }
 
         let text = res
@@ -361,8 +360,7 @@ impl DavCalendar for RemoteCalendar {
             return Err(KFError::UnexpectedHTTPStatusCode {
                 expected: HttpStatusConstraint::Success,
                 got: del_response.status(),
-            }
-            .into());
+            });
         }
 
         Ok(())

--- a/src/calendar/remote_calendar.rs
+++ b/src/calendar/remote_calendar.rs
@@ -56,7 +56,7 @@ impl BaseCalendar for RemoteCalendar {
         &self.name
     }
     fn url(&self) -> &Url {
-        &self.resource.url()
+        self.resource.url()
     }
     fn supported_components(&self) -> crate::calendar::SupportedComponents {
         self.supported_components
@@ -78,7 +78,7 @@ impl BaseCalendar for RemoteCalendar {
             .send()
             .await?;
 
-        if response.status().is_success() == false {
+        if !response.status().is_success() {
             return Err(format!("Unexpected HTTP status code {:?}", response.status()).into());
         }
 
@@ -121,7 +121,7 @@ impl BaseCalendar for RemoteCalendar {
             .send()
             .await?;
 
-        if request.status().is_success() == false {
+        if !request.status().is_success() {
             return Err(format!("Unexpected HTTP status code {:?}", request.status()).into());
         }
 
@@ -209,7 +209,7 @@ impl DavCalendar for RemoteCalendar {
             .send()
             .await?;
 
-        if res.status().is_success() == false {
+        if !res.status().is_success() {
             return Err(format!("Unexpected HTTP status code {:?}", res.status()).into());
         }
 
@@ -275,7 +275,7 @@ impl DavCalendar for RemoteCalendar {
             .send()
             .await?;
 
-        if del_response.status().is_success() == false {
+        if !del_response.status().is_success() {
             return Err(format!("Unexpected HTTP status code {:?}", del_response.status()).into());
         }
 

--- a/src/calendar/remote_calendar.rs
+++ b/src/calendar/remote_calendar.rs
@@ -213,7 +213,7 @@ impl DavCalendar for RemoteCalendar {
         }
     }
 
-    async fn get_item_version_tags(&self) -> Result<HashMap<Url, VersionTag>, Box<dyn Error>> {
+    async fn get_item_version_tags(&self) -> KFResult<HashMap<Url, VersionTag>> {
         if let Some(map) = &*self.cached_version_tags.lock().unwrap() {
             log::debug!("Version tags are already cached.");
             return Ok(map.clone());

--- a/src/client.rs
+++ b/src/client.rs
@@ -105,7 +105,12 @@ pub(crate) async fn sub_request_and_extract_elem(
     for item in items {
         current_element = match find_elem(current_element, item) {
             Some(elem) => elem,
-            None => return Err(KFError::MissingExpectedDOMElement(item.to_string())),
+            None => {
+                return Err(KFError::MissingDOMElement {
+                    text: current_element.text(),
+                    el: item.to_string(),
+                })
+            }
         }
     }
     Ok(current_element.text())

--- a/src/client.rs
+++ b/src/client.rs
@@ -96,7 +96,7 @@ pub(crate) async fn sub_request_and_extract_elem(
     resource: &Resource,
     body: String,
     items: &[&str],
-) -> Result<String, KFError> {
+) -> KFResult<String> {
     let text = sub_request(resource, "PROPFIND", body, 0).await?;
 
     let mut current_element: &Element = &text
@@ -116,7 +116,7 @@ pub(crate) async fn sub_request_and_extract_elems(
     method: &str,
     body: String,
     item: &str,
-) -> Result<Vec<Element>, KFError> {
+) -> KFResult<Vec<Element>> {
     let text = sub_request(resource, method, body, 1).await?;
 
     let element: &Element = &text

--- a/src/client.rs
+++ b/src/client.rs
@@ -170,7 +170,7 @@ impl Client {
     }
 
     /// Return the Homeset URL, or fetch it from server if not known yet
-    async fn get_cal_home_set(&self) -> Result<Resource, Box<dyn Error>> {
+    pub async fn get_cal_home_set(&self) -> Result<Resource, Box<dyn Error>> {
         if let Some(h) = &self.cached_replies.lock().unwrap().calendar_home_set {
             return Ok(h.clone());
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 use crate::calendar::remote_calendar::RemoteCalendar;
 use crate::calendar::SupportedComponents;
-use crate::error::{HttpStatusConstraint, KFError};
+use crate::error::{HttpStatusConstraint, KFError, KFResult};
 use crate::item::ItemType;
 use crate::resource::Resource;
 use crate::traits::BaseCalendar;
@@ -291,9 +291,7 @@ impl Client {
 
 #[async_trait]
 impl CalDavSource<RemoteCalendar> for Client {
-    async fn get_calendars(
-        &self,
-    ) -> Result<HashMap<Url, Arc<Mutex<RemoteCalendar>>>, Box<dyn Error>> {
+    async fn get_calendars(&self) -> KFResult<HashMap<Url, Arc<Mutex<RemoteCalendar>>>> {
         self.populate_calendars().await?;
 
         Ok(self

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,7 +65,7 @@ pub(crate) async fn sub_request(
         .send()
         .await?;
 
-    if res.status().is_success() == false {
+    if !res.status().is_success() {
         return Err(format!("Unexpected HTTP status code {:?}", res.status()).into());
     }
 
@@ -82,7 +82,7 @@ pub(crate) async fn sub_request_and_extract_elem(
 
     let mut current_element: &Element = &text.parse()?;
     for item in items {
-        current_element = match find_elem(&current_element, item) {
+        current_element = match find_elem(current_element, item) {
             Some(elem) => elem,
             None => return Err(format!("missing element {}", item).into()),
         }
@@ -99,7 +99,7 @@ pub(crate) async fn sub_request_and_extract_elems(
     let text = sub_request(resource, method, body, 1).await?;
 
     let element: &Element = &text.parse()?;
-    Ok(find_elems(&element, item)
+    Ok(find_elems(element, item)
         .iter()
         .map(|elem| (*elem).clone())
         .collect())
@@ -153,7 +153,7 @@ impl Client {
         self.cached_replies.lock().unwrap().principal = Some(principal_url.clone());
         log::debug!("Principal URL is {}", href);
 
-        return Ok(principal_url);
+        Ok(principal_url)
     }
 
     /// Return the Homeset URL, or fetch it from server if not known yet
@@ -205,7 +205,7 @@ impl Client {
                     break;
                 }
             }
-            if found_calendar_type == false {
+            if !found_calendar_type {
                 continue;
             }
 
@@ -291,7 +291,7 @@ impl CalDavSource<RemoteCalendar> for Client {
             .calendars
             .as_ref()
             .and_then(|cals| cals.get(url))
-            .map(|cal| cal.clone())
+            .cloned()
     }
 
     async fn create_calendar(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,14 @@
 //! Support for library configuration options
 
-use std::sync::{Arc, Mutex};
 use once_cell::sync::Lazy;
+use std::sync::{Arc, Mutex};
 
 /// Part of the ProdID string that describes the organization (example of a ProdID string: `-//ABC Corporation//My Product//EN`).
 /// Feel free to override it when initing this library.
-pub static ORG_NAME: Lazy<Arc<Mutex<String>>> = Lazy::new(|| Arc::new(Mutex::new("My organization".to_string())));
+pub static ORG_NAME: Lazy<Arc<Mutex<String>>> =
+    Lazy::new(|| Arc::new(Mutex::new("My organization".to_string())));
 
 /// Part of the ProdID string that describes the product name (example of a ProdID string: `-//ABC Corporation//My Product//EN`).
 /// Feel free to override it when initing this library.
-pub static PRODUCT_NAME: Lazy<Arc<Mutex<String>>> = Lazy::new(|| Arc::new(Mutex::new("KitchenFridge".to_string())));
+pub static PRODUCT_NAME: Lazy<Arc<Mutex<String>>> =
+    Lazy::new(|| Arc::new(Mutex::new("KitchenFridge".to_string())));

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use reqwest::StatusCode;
 use url::Url;
 
-use crate::item::ItemType;
+use crate::{calendar::remote_calendar::RemoteCalendarError, item::ItemType};
 
 #[derive(Debug)]
 pub enum HttpStatusConstraint {
@@ -25,6 +25,16 @@ pub enum KFError {
         source: minidom::Error,
     },
 
+    #[error("Generic error: {0}")]
+    GenericError(#[from] Box<dyn std::error::Error>),
+
+    #[error("HTTP request {method} {url} resulted in an error: {source}")]
+    HttpRequestError {
+        url: Url,
+        method: http::Method,
+        source: reqwest::Error,
+    },
+
     #[error("{detail}; {type_:?} {url:?} already exists")]
     ItemAlreadyExists {
         type_: ItemType,
@@ -39,13 +49,6 @@ pub enum KFError {
         url: Url,
     },
 
-    #[error("HTTP request {method} {url} resulted in an error: {source}")]
-    HttpRequestError {
-        url: Url,
-        method: http::Method,
-        source: reqwest::Error,
-    },
-
     #[error("Missing DOM element {0}")]
     MissingExpectedDOMElement(String),
 
@@ -53,9 +56,14 @@ pub enum KFError {
     #[cfg(feature = "local_calendar_mocks_remote_calendars")]
     MockError(#[from] crate::mock_behaviour::MockError),
 
+    #[error("Remote calendar error: {0}")]
+    RemoteCalendarError(#[from] RemoteCalendarError),
+
     #[error("Unexpected HTTP status code {got:?} but expected {expected:?}")]
     UnexpectedHTTPStatusCode {
         expected: HttpStatusConstraint,
         got: StatusCode,
     },
 }
+
+pub type KFResult<T> = Result<T, KFError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,9 +25,6 @@ pub enum KFError {
         source: minidom::Error,
     },
 
-    #[error("Generic error: {0}")]
-    GenericError(#[from] Box<dyn std::error::Error>),
-
     #[error("HTTP request {method} {url} resulted in an error: {source}")]
     HttpRequestError {
         url: Url,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,34 @@
+use reqwest::StatusCode;
+use url::Url;
+
+use crate::item::ItemType;
+
+#[derive(Debug)]
+pub enum HttpStatusConstraint {
+    Success,
+    Specific(StatusCode),
+}
+
+/// Errors common to the Kitchen Fridge library
+#[derive(thiserror::Error, Debug)]
+pub enum KFError {
+    #[error("{detail}; {type_:?} {url:?} already exists")]
+    ItemAlreadyExists {
+        type_: ItemType,
+        detail: String,
+        url: Url,
+    },
+
+    #[error("{detail}; {type_:?} {url:?} does not exist")]
+    ItemDoesNotExist {
+        type_: Option<ItemType>,
+        detail: String,
+        url: Url,
+    },
+
+    #[error("Unexpected HTTP status code {got:?} but expected {expected:?}")]
+    UnexpectedHTTPStatusCode {
+        expected: HttpStatusConstraint,
+        got: StatusCode,
+    },
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,8 +49,13 @@ pub enum KFError {
         url: Url,
     },
 
-    #[error("Missing DOM element {0}")]
-    MissingExpectedDOMElement(String),
+    #[error("Missing DOM element {el} in {text}")]
+    MissingDOMElement {
+        /// The text that should have contained the element
+        text: String,
+        /// The element
+        el: String,
+    },
 
     #[error("An error occurred while mocking behavior: {0}")]
     #[cfg(feature = "local_calendar_mocks_remote_calendars")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use reqwest::StatusCode;
 use url::Url;
 
-use crate::{calendar::remote_calendar::RemoteCalendarError, item::ItemType};
+use crate::{calendar::remote_calendar::RemoteCalendarError, ical::IcalParseError, item::ItemType};
 
 #[derive(Debug)]
 pub enum HttpStatusConstraint {
@@ -34,6 +34,9 @@ pub enum KFError {
         method: http::Method,
         source: reqwest::Error,
     },
+
+    #[error("Error parsing ical data: {0}")]
+    IcalParseError(#[from] IcalParseError),
 
     #[error("{detail}; {type_:?} {url:?} already exists")]
     ItemAlreadyExists {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,19 @@ pub enum HttpStatusConstraint {
 /// Errors common to the Kitchen Fridge library
 #[derive(thiserror::Error, Debug)]
 pub enum KFError {
+    #[error(
+        "Calendar at URL {0} didn't appear in the client cache after being created on the server"
+    )]
+    CalendarDidNotSyncAfterCreation(Url),
+
+    #[error("Error parsing '{text}': {source}")]
+    DOMParseError {
+        /// The text being parsed
+        text: String,
+
+        source: minidom::Error,
+    },
+
     #[error("{detail}; {type_:?} {url:?} already exists")]
     ItemAlreadyExists {
         type_: ItemType,
@@ -25,6 +38,20 @@ pub enum KFError {
         detail: String,
         url: Url,
     },
+
+    #[error("HTTP request {method} {url} resulted in an error: {source}")]
+    HttpRequestError {
+        url: Url,
+        method: http::Method,
+        source: reqwest::Error,
+    },
+
+    #[error("Missing DOM element {0}")]
+    MissingExpectedDOMElement(String),
+
+    #[error("An error occurred while mocking behavior: {0}")]
+    #[cfg(feature = "local_calendar_mocks_remote_calendars")]
+    MockError(#[from] crate::mock_behaviour::MockError),
 
     #[error("Unexpected HTTP status code {got:?} but expected {expected:?}")]
     UnexpectedHTTPStatusCode {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,7 @@
 //! Calendar events (iCal `VEVENT` items)
 
-use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::item::SyncStatus;

--- a/src/ical/builder.rs
+++ b/src/ical/builder.rs
@@ -26,8 +26,10 @@ pub fn build_from_task(task: &Task) -> Result<String, Box<dyn Error>> {
 
     let mut todo = ToDo::new(task.uid(), s_last_modified.clone());
 
-    task.creation_date()
-        .map(|dt| todo.push(Created::new(format_date_time(dt))));
+    if let Some(dt) = task.creation_date() {
+        todo.push(Created::new(format_date_time(dt)));
+    }
+
     todo.push(LastModified::new(s_last_modified));
     todo.push(Summary::new(task.name()));
 
@@ -37,9 +39,9 @@ pub fn build_from_task(task: &Task) -> Result<String, Box<dyn Error>> {
         }
         CompletionStatus::Completed(completion_date) => {
             todo.push(PercentComplete::new("100"));
-            completion_date
-                .as_ref()
-                .map(|dt| todo.push(Completed::new(format_date_time(dt))));
+            if let Some(dt) = completion_date.as_ref() {
+                todo.push(Completed::new(format_date_time(dt)));
+            }
             todo.push(Status::completed());
         }
     }
@@ -65,12 +67,12 @@ fn ical_to_ics_property(prop: IcalProperty) -> IcsProperty<'static> {
         Some(value) => IcsProperty::new(prop.name, value),
         None => IcsProperty::new(prop.name, ""),
     };
-    prop.params.map(|v| {
+    if let Some(v) = prop.params {
         for (key, vec_values) in v {
             let values = vec_values.join(";");
             ics_prop.add(IcsParameter::new(key, values));
         }
-    });
+    }
     ics_prop
 }
 

--- a/src/ical/builder.rs
+++ b/src/ical/builder.rs
@@ -1,7 +1,5 @@
 //! A module to build ICal files
 
-use std::error::Error;
-
 use chrono::{DateTime, Utc};
 use ical::property::Property as IcalProperty;
 use ics::components::Parameter as IcsParameter;
@@ -14,14 +12,14 @@ use crate::task::CompletionStatus;
 use crate::Task;
 
 /// Create an iCal item from a `crate::item::Item`
-pub fn build_from(item: &Item) -> Result<String, Box<dyn Error>> {
+pub fn build_from(item: &Item) -> String {
     match item {
         Item::Task(t) => build_from_task(t),
         _ => unimplemented!(),
     }
 }
 
-pub fn build_from_task(task: &Task) -> Result<String, Box<dyn Error>> {
+pub fn build_from_task(task: &Task) -> String {
     let s_last_modified = format_date_time(task.last_modified());
 
     let mut todo = ToDo::new(task.uid(), s_last_modified.clone());
@@ -55,7 +53,7 @@ pub fn build_from_task(task: &Task) -> Result<String, Box<dyn Error>> {
     let mut calendar = ICalendar::new("2.0", task.ical_prod_id());
     calendar.add_todo(todo);
 
-    Ok(calendar.to_string())
+    calendar.to_string()
 }
 
 fn format_date_time(dt: &DateTime<Utc>) -> String {
@@ -152,7 +150,7 @@ mod tests {
             &cal_url,
         ));
 
-        let ical = build_from(&task).unwrap();
+        let ical = build_from(&task);
         (s_now, task.uid().to_string(), ical)
     }
 

--- a/src/ical/mod.rs
+++ b/src/ical/mod.rs
@@ -10,21 +10,24 @@ pub use builder::build_from;
 use crate::config::{ORG_NAME, PRODUCT_NAME};
 
 pub fn default_prod_id() -> String {
-    format!("-//{}//{}//EN", ORG_NAME.lock().unwrap(), PRODUCT_NAME.lock().unwrap())
+    format!(
+        "-//{}//{}//EN",
+        ORG_NAME.lock().unwrap(),
+        PRODUCT_NAME.lock().unwrap()
+    )
 }
-
-
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use std::collections::HashSet;
     use crate::item::SyncStatus;
+    use std::collections::HashSet;
 
     #[test]
     fn test_ical_round_trip_serde() {
-        let ical_with_unknown_fields = std::fs::read_to_string("tests/assets/ical_with_unknown_fields.ics").unwrap();
+        let ical_with_unknown_fields =
+            std::fs::read_to_string("tests/assets/ical_with_unknown_fields.ics").unwrap();
 
         let item_id = "http://item.id".parse().unwrap();
         let sync_status = SyncStatus::NotSynced;

--- a/src/ical/mod.rs
+++ b/src/ical/mod.rs
@@ -4,6 +4,7 @@
 
 mod parser;
 pub use parser::parse;
+pub use parser::IcalParseError;
 mod builder;
 pub use builder::build_from;
 
@@ -32,7 +33,7 @@ mod tests {
         let item_id = "http://item.id".parse().unwrap();
         let sync_status = SyncStatus::NotSynced;
         let deserialized = parse(&ical_with_unknown_fields, item_id, sync_status).unwrap();
-        let serialized = build_from(&deserialized).unwrap();
+        let serialized = build_from(&deserialized);
         assert_same_fields(&ical_with_unknown_fields, &serialized);
     }
 

--- a/src/ical/parser.rs
+++ b/src/ical/parser.rs
@@ -2,26 +2,33 @@
 
 use std::error::Error;
 
-use ical::parser::ical::component::{IcalCalendar, IcalEvent, IcalTodo};
 use chrono::{DateTime, TimeZone, Utc};
+use ical::parser::ical::component::{IcalCalendar, IcalEvent, IcalTodo};
 use url::Url;
 
-use crate::Item;
 use crate::item::SyncStatus;
-use crate::Task;
 use crate::task::CompletionStatus;
 use crate::Event;
-
+use crate::Item;
+use crate::Task;
 
 /// Parse an iCal file into the internal representation [`crate::Item`]
-pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<Item, Box<dyn Error>> {
+pub fn parse(
+    content: &str,
+    item_url: Url,
+    sync_status: SyncStatus,
+) -> Result<Item, Box<dyn Error>> {
     let mut reader = ical::IcalParser::new(content.as_bytes());
     let parsed_item = match reader.next() {
         None => return Err(format!("Invalid iCal data to parse for item {}", item_url).into()),
         Some(item) => match item {
-            Err(err) => return Err(format!("Unable to parse iCal data for item {}: {}", item_url, err).into()),
+            Err(err) => {
+                return Err(
+                    format!("Unable to parse iCal data for item {}: {}", item_url, err).into(),
+                )
+            }
             Ok(item) => item,
-        }
+        },
     };
 
     let ical_prod_id = extract_ical_prod_id(&parsed_item)
@@ -29,9 +36,7 @@ pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<It
         .unwrap_or_else(|| super::default_prod_id());
 
     let item = match assert_single_type(&parsed_item)? {
-        CurrentType::Event(_) => {
-            Item::Event(Event::new())
-        },
+        CurrentType::Event(_) => Item::Event(Event::new()),
 
         CurrentType::Todo(todo) => {
             let mut name = None;
@@ -44,8 +49,8 @@ pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<It
 
             for prop in &todo.properties {
                 match prop.name.as_str() {
-                    "SUMMARY" => { name = prop.value.clone() },
-                    "UID" => { uid = prop.value.clone() },
+                    "SUMMARY" => name = prop.value.clone(),
+                    "UID" => uid = prop.value.clone(),
                     "DTSTAMP" => {
                         // The property can be specified once, but is not mandatory
                         // "This property specifies the date and time that the information associated with
@@ -53,7 +58,7 @@ pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<It
                         // "In the case of an iCalendar object that doesn't specify a "METHOD"
                         //  property [e.g.: VTODO and VEVENT], this property is equivalent to the "LAST-MODIFIED" property".
                         last_modified = parse_date_time_from_property(&prop.value);
-                    },
+                    }
                     "LAST-MODIFIED" => {
                         // The property can be specified once, but is not mandatory
                         // "This property specifies the date and time that the information associated with
@@ -66,11 +71,11 @@ pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<It
                         // "This property defines the date and time that a to-do was
                         //  actually completed."
                         completion_date = parse_date_time_from_property(&prop.value)
-                    },
+                    }
                     "CREATED" => {
                         // The property can be specified once, but is not mandatory
                         creation_date = parse_date_time_from_property(&prop.value)
-                    },
+                    }
                     "STATUS" => {
                         // Possible values:
                         //   "NEEDS-ACTION" ;Indicates to-do needs action.
@@ -97,7 +102,13 @@ pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<It
             };
             let last_modified = match last_modified {
                 Some(dt) => dt,
-                None => return Err(format!("Missing DTSTAMP for item {}, but this is required by RFC5545", item_url).into()),
+                None => {
+                    return Err(format!(
+                        "Missing DTSTAMP for item {}, but this is required by RFC5545",
+                        item_url
+                    )
+                    .into())
+                }
             };
             let completion_status = match completed {
                 false => {
@@ -105,14 +116,23 @@ pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<It
                         log::warn!("Task {:?} has an inconsistent content: its STATUS is not completed, yet it has a COMPLETED timestamp at {:?}", uid, completion_date);
                     }
                     CompletionStatus::Uncompleted
-                },
+                }
                 true => CompletionStatus::Completed(completion_date),
             };
 
-            Item::Task(Task::new_with_parameters(name, uid, item_url, completion_status, sync_status, creation_date, last_modified, ical_prod_id, extra_parameters))
-        },
+            Item::Task(Task::new_with_parameters(
+                name,
+                uid,
+                item_url,
+                completion_status,
+                sync_status,
+                creation_date,
+                last_modified,
+                ical_prod_id,
+                extra_parameters,
+            ))
+        }
     };
-
 
     // What to do with multiple items?
     if reader.next().map(|r| r.is_ok()) == Some(true) {
@@ -123,32 +143,29 @@ pub fn parse(content: &str, item_url: Url, sync_status: SyncStatus) -> Result<It
 }
 
 fn parse_date_time(dt: &str) -> Result<DateTime<Utc>, chrono::format::ParseError> {
-                    Utc.datetime_from_str(dt, "%Y%m%dT%H%M%SZ")
-    .or_else(|_err| Utc.datetime_from_str(dt, "%Y%m%dT%H%M%S") )
+    Utc.datetime_from_str(dt, "%Y%m%dT%H%M%SZ")
+        .or_else(|_err| Utc.datetime_from_str(dt, "%Y%m%dT%H%M%S"))
 }
 
 fn parse_date_time_from_property(value: &Option<String>) -> Option<DateTime<Utc>> {
-    value.as_ref()
-        .and_then(|s| {
-            parse_date_time(s)
+    value.as_ref().and_then(|s| {
+        parse_date_time(s)
             .map_err(|err| {
                 log::warn!("Invalid timestamp: {}", s);
                 err
             })
             .ok()
-        })
+    })
 }
-
 
 fn extract_ical_prod_id(item: &IcalCalendar) -> Option<&str> {
     for prop in &item.properties {
         if &prop.name == "PRODID" {
-            return prop.value.as_ref().map(|s| s.as_str())
+            return prop.value.as_ref().map(|s| s.as_str());
         }
     }
     None
 }
-
 
 enum CurrentType<'a> {
     Event(&'a IcalEvent),
@@ -179,7 +196,6 @@ fn assert_single_type<'a>(item: &'a IcalCalendar) -> Result<CurrentType<'a>, Box
     return Err("Only a single TODO or a single EVENT is supported".into());
 }
 
-
 #[cfg(test)]
 mod test {
     const EXAMPLE_ICAL: &str = r#"BEGIN:VCALENDAR
@@ -195,7 +211,7 @@ END:VTODO
 END:VCALENDAR
 "#;
 
-const EXAMPLE_ICAL_COMPLETED: &str = r#"BEGIN:VCALENDAR
+    const EXAMPLE_ICAL_COMPLETED: &str = r#"BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Nextcloud Tasks v0.13.6
 BEGIN:VTODO
@@ -211,7 +227,7 @@ END:VTODO
 END:VCALENDAR
 "#;
 
-const EXAMPLE_ICAL_COMPLETED_WITHOUT_A_COMPLETION_DATE: &str = r#"BEGIN:VCALENDAR
+    const EXAMPLE_ICAL_COMPLETED_WITHOUT_A_COMPLETION_DATE: &str = r#"BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Nextcloud Tasks v0.13.6
 BEGIN:VTODO
@@ -261,11 +277,17 @@ END:VCALENDAR
 
         assert_eq!(task.name(), "Do not forget to do this");
         assert_eq!(task.url(), &item_url);
-        assert_eq!(task.uid(), "0633de27-8c32-42be-bcb8-63bc879c6185@some-domain.com");
+        assert_eq!(
+            task.uid(),
+            "0633de27-8c32-42be-bcb8-63bc879c6185@some-domain.com"
+        );
         assert_eq!(task.completed(), false);
         assert_eq!(task.completion_status(), &CompletionStatus::Uncompleted);
         assert_eq!(task.sync_status(), &sync_status);
-        assert_eq!(task.last_modified(), &Utc.ymd(2021, 03, 21).and_hms(0, 16, 0));
+        assert_eq!(
+            task.last_modified(),
+            &Utc.ymd(2021, 03, 21).and_hms(0, 16, 0)
+        );
     }
 
     #[test]
@@ -274,11 +296,19 @@ END:VCALENDAR
         let sync_status = SyncStatus::Synced(version_tag);
         let item_url: Url = "http://some.id/for/testing".parse().unwrap();
 
-        let item = parse(EXAMPLE_ICAL_COMPLETED, item_url.clone(), sync_status.clone()).unwrap();
+        let item = parse(
+            EXAMPLE_ICAL_COMPLETED,
+            item_url.clone(),
+            sync_status.clone(),
+        )
+        .unwrap();
         let task = item.unwrap_task();
 
         assert_eq!(task.completed(), true);
-        assert_eq!(task.completion_status(), &CompletionStatus::Completed(Some(Utc.ymd(2021, 04, 02).and_hms(8, 15, 57))));
+        assert_eq!(
+            task.completion_status(),
+            &CompletionStatus::Completed(Some(Utc.ymd(2021, 04, 02).and_hms(8, 15, 57)))
+        );
     }
 
     #[test]
@@ -287,7 +317,12 @@ END:VCALENDAR
         let sync_status = SyncStatus::Synced(version_tag);
         let item_url: Url = "http://some.id/for/testing".parse().unwrap();
 
-        let item = parse(EXAMPLE_ICAL_COMPLETED_WITHOUT_A_COMPLETION_DATE, item_url.clone(), sync_status.clone()).unwrap();
+        let item = parse(
+            EXAMPLE_ICAL_COMPLETED_WITHOUT_A_COMPLETION_DATE,
+            item_url.clone(),
+            sync_status.clone(),
+        )
+        .unwrap();
         let task = item.unwrap_task();
 
         assert_eq!(task.completed(), true);

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,10 +1,9 @@
 //! CalDAV items (todo, events, journals...)
 // TODO: move Event and Task to nest them in crate::items::calendar::Calendar?
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use url::Url;
-use chrono::{DateTime, Utc};
-
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Item {
@@ -21,7 +20,7 @@ macro_rules! synthetise_common_getter {
                 Item::Task(t) => t.$property_name(),
             }
         }
-    }
+    };
 }
 
 impl Item {
@@ -80,19 +79,16 @@ impl Item {
     pub fn has_same_observable_content_as(&self, other: &Item) -> bool {
         match (self, other) {
             (Item::Event(s), Item::Event(o)) => s.has_same_observable_content_as(o),
-            (Item::Task(s),  Item::Task(o))  => s.has_same_observable_content_as(o),
+            (Item::Task(s), Item::Task(o)) => s.has_same_observable_content_as(o),
             _ => false,
         }
     }
 }
 
-
-
-
 /// A VersionTag is basically a CalDAV `ctag` or `etag`. Whenever it changes, this means the data has changed.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VersionTag {
-    tag: String
+    tag: String,
 }
 
 impl From<String> for VersionTag {
@@ -114,8 +110,6 @@ impl VersionTag {
         Self { tag: random }
     }
 }
-
-
 
 /// Describes whether this item has been synced already, or modified since the last time it was synced
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/item.rs
+++ b/src/item.rs
@@ -5,6 +5,13 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+#[derive(Debug)]
+pub enum ItemType {
+    Calendar,
+    Event,
+    Task,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Item {
     Event(crate::event::Event),
@@ -75,6 +82,13 @@ impl Item {
             (Item::Event(s), Item::Event(o)) => s.has_same_observable_content_as(o),
             (Item::Task(s), Item::Task(o)) => s.has_same_observable_content_as(o),
             _ => false,
+        }
+    }
+
+    pub fn type_(&self) -> ItemType {
+        match self {
+            Self::Event(_) => ItemType::Event,
+            Self::Task(_) => ItemType::Task,
         }
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -40,17 +40,11 @@ impl Item {
     }
 
     pub fn is_event(&self) -> bool {
-        match &self {
-            Item::Event(_) => true,
-            _ => false,
-        }
+        matches!(self, Item::Event(_))
     }
 
     pub fn is_task(&self) -> bool {
-        match &self {
-            Item::Task(_) => true,
-            _ => false,
-        }
+        matches!(self, Item::Task(_))
     }
 
     /// Returns a mutable reference to the inner Task

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@
 //!
 //! Have a look at the [`config`] module to see what default options can be overridden.
 
-#![doc(html_logo_url = "https://raw.githubusercontent.com/daladim/kitchen-fridge/master/resources/kitchen-fridge.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/daladim/kitchen-fridge/master/resources/kitchen-fridge.svg"
+)]
 
 pub mod traits;
 
@@ -38,8 +40,8 @@ pub mod task;
 pub use task::Task;
 pub mod event;
 pub use event::Event;
-pub mod provider;
 pub mod mock_behaviour;
+pub mod provider;
 
 pub mod client;
 pub use client::Client;
@@ -48,9 +50,14 @@ pub use cache::Cache;
 pub mod ical;
 
 pub mod config;
-pub mod utils;
 pub mod resource;
+pub mod utils;
 
 /// Unless you want another kind of Provider to write integration tests, you'll probably want this kind of Provider. \
 /// See alse the [`Provider` documentation](crate::provider::Provider)
-pub type CalDavProvider = provider::Provider<cache::Cache, calendar::cached_calendar::CachedCalendar, Client, calendar::remote_calendar::RemoteCalendar>;
+pub type CalDavProvider = provider::Provider<
+    cache::Cache,
+    calendar::cached_calendar::CachedCalendar,
+    Client,
+    calendar::remote_calendar::RemoteCalendar,
+>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
     html_logo_url = "https://raw.githubusercontent.com/daladim/kitchen-fridge/master/resources/kitchen-fridge.svg"
 )]
 
+pub mod error;
+
 pub mod traits;
 
 pub mod calendar;

--- a/src/mock_behaviour.rs
+++ b/src/mock_behaviour.rs
@@ -61,7 +61,9 @@ impl MockBehaviour {
     }
 
     pub fn can_get_calendars(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.is_suspended { return Ok(()) }
+        if self.is_suspended {
+            return Ok(());
+        }
         decrement(&mut self.get_calendars_behaviour, "get_calendars")
     }
     // pub fn can_get_calendar(&mut self) -> Result<(), Box<dyn Error>> {
@@ -69,31 +71,45 @@ impl MockBehaviour {
     //     decrement(&mut self.get_calendar_behaviour, "get_calendar")
     // }
     pub fn can_create_calendar(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.is_suspended { return Ok(()) }
+        if self.is_suspended {
+            return Ok(());
+        }
         decrement(&mut self.create_calendar_behaviour, "create_calendar")
     }
     pub fn can_add_item(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.is_suspended { return Ok(()) }
+        if self.is_suspended {
+            return Ok(());
+        }
         decrement(&mut self.add_item_behaviour, "add_item")
     }
     pub fn can_update_item(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.is_suspended { return Ok(()) }
+        if self.is_suspended {
+            return Ok(());
+        }
         decrement(&mut self.update_item_behaviour, "update_item")
     }
     pub fn can_get_item_version_tags(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.is_suspended { return Ok(()) }
-        decrement(&mut self.get_item_version_tags_behaviour, "get_item_version_tags")
+        if self.is_suspended {
+            return Ok(());
+        }
+        decrement(
+            &mut self.get_item_version_tags_behaviour,
+            "get_item_version_tags",
+        )
     }
     pub fn can_get_item_by_url(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.is_suspended { return Ok(()) }
+        if self.is_suspended {
+            return Ok(());
+        }
         decrement(&mut self.get_item_by_url_behaviour, "get_item_by_url")
     }
     pub fn can_delete_item(&mut self) -> Result<(), Box<dyn Error>> {
-        if self.is_suspended { return Ok(()) }
+        if self.is_suspended {
+            return Ok(());
+        }
         decrement(&mut self.delete_item_behaviour, "delete_item")
     }
 }
-
 
 /// Return Ok(()) in case the value is `(1+, _)` or `(_, 0)`, or return Err and decrement otherwise
 fn decrement(value: &mut (u32, u32), descr: &str) -> Result<(), Box<dyn Error>> {
@@ -108,7 +124,11 @@ fn decrement(value: &mut (u32, u32), descr: &str) -> Result<(), Box<dyn Error>> 
         if remaining_failures > 0 {
             value.1 = value.1 - 1;
             log::debug!("Mock behaviour: failing a {} ({:?})", descr, value);
-            Err(format!("Mocked behaviour requires this {} to fail this time. ({:?})", descr, value).into())
+            Err(format!(
+                "Mocked behaviour requires this {} to fail this time. ({:?})",
+                descr, value
+            )
+            .into())
         } else {
             log::debug!("Mock behaviour: allowing a {} ({:?})", descr, value);
             Ok(())
@@ -140,9 +160,9 @@ mod test {
         assert!(now.can_get_calendars().is_ok());
         assert!(now.can_create_calendar().is_ok());
 
-        let mut custom = MockBehaviour{
-            get_calendars_behaviour: (0,1),
-            create_calendar_behaviour: (1,3),
+        let mut custom = MockBehaviour {
+            get_calendars_behaviour: (0, 1),
+            create_calendar_behaviour: (1, 3),
             ..MockBehaviour::default()
         };
         assert!(custom.can_get_calendars().is_err());

--- a/src/mock_behaviour.rs
+++ b/src/mock_behaviour.rs
@@ -117,22 +117,20 @@ fn decrement(value: &mut (u32, u32), descr: &str) -> Result<(), Box<dyn Error>> 
     let remaining_failures = value.1;
 
     if remaining_successes > 0 {
-        value.0 = value.0 - 1;
+        value.0 -= 1;
         log::debug!("Mock behaviour: allowing a {} ({:?})", descr, value);
         Ok(())
+    } else if remaining_failures > 0 {
+        value.1 -= 1;
+        log::debug!("Mock behaviour: failing a {} ({:?})", descr, value);
+        Err(format!(
+            "Mocked behaviour requires this {} to fail this time. ({:?})",
+            descr, value
+        )
+        .into())
     } else {
-        if remaining_failures > 0 {
-            value.1 = value.1 - 1;
-            log::debug!("Mock behaviour: failing a {} ({:?})", descr, value);
-            Err(format!(
-                "Mocked behaviour requires this {} to fail this time. ({:?})",
-                descr, value
-            )
-            .into())
-        } else {
-            log::debug!("Mock behaviour: allowing a {} ({:?})", descr, value);
-            Ok(())
-        }
+        log::debug!("Mock behaviour: allowing a {} ({:?})", descr, value);
+        Ok(())
     }
 }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -2,18 +2,18 @@
 //!
 //! It is also responsible for syncing them together
 
-use std::error::Error;
 use std::collections::HashSet;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
-use std::fmt::{Display, Formatter};
 
-use url::Url;
 use itertools::Itertools;
+use url::Url;
 
-use crate::traits::{BaseCalendar, CalDavSource, DavCalendar};
-use crate::traits::CompleteCalendar;
 use crate::item::SyncStatus;
+use crate::traits::CompleteCalendar;
+use crate::traits::{BaseCalendar, CalDavSource, DavCalendar};
 
 pub mod sync_progress;
 use sync_progress::SyncProgress;
@@ -41,7 +41,6 @@ impl Display for BatchDownloadType {
         }
     }
 }
-
 
 /// A data source that combines two `CalDavSource`s, which is able to sync both sources.
 ///
@@ -76,21 +75,30 @@ where
     /// `remote` is usually a [`Client`](crate::client::Client), `local` is usually a [`Cache`](crate::cache::Cache).
     /// However, both can be interchangeable. The only difference is that `remote` always wins in case of a sync conflict
     pub fn new(remote: R, local: L) -> Self {
-        Self { remote, local,
-            phantom_t: PhantomData, phantom_u: PhantomData,
+        Self {
+            remote,
+            local,
+            phantom_t: PhantomData,
+            phantom_u: PhantomData,
         }
     }
 
     /// Returns the data source described as `local`
-    pub fn local(&self)  -> &L { &self.local }
+    pub fn local(&self) -> &L {
+        &self.local
+    }
     /// Returns the data source described as `local`
-    pub fn local_mut(&mut self)  -> &mut L { &mut self.local }
+    pub fn local_mut(&mut self) -> &mut L {
+        &mut self.local
+    }
     /// Returns the data source described as `remote`.
     ///
     /// Apart from tests, there are very few (if any) reasons to access `remote` directly.
     /// Usually, you should rather use the `local` source, which (usually) is a much faster local cache.
     /// To be sure `local` accurately mirrors the `remote` source, you can run [`Provider::sync`]
-    pub fn remote(&self) -> &R { &self.remote }
+    pub fn remote(&self) -> &R {
+        &self.remote
+    }
 
     /// Performs a synchronisation between `local` and `remote`, and provide feeedback to the user about the progress.
     ///
@@ -117,7 +125,9 @@ where
         if let Err(err) = self.run_sync_inner(progress).await {
             progress.error(&format!("Sync terminated because of an error: {}", err));
         }
-        progress.feedback(SyncEvent::Finished{ success: progress.is_success() });
+        progress.feedback(SyncEvent::Finished {
+            success: progress.is_success(),
+        });
         progress.is_success()
     }
 
@@ -130,16 +140,22 @@ where
         // Sync every remote calendar
         let cals_remote = self.remote.get_calendars().await?;
         for (cal_url, cal_remote) in cals_remote {
-            let counterpart = match self.get_or_insert_local_counterpart_calendar(&cal_url, cal_remote.clone()).await {
+            let counterpart = match self
+                .get_or_insert_local_counterpart_calendar(&cal_url, cal_remote.clone())
+                .await
+            {
                 Err(err) => {
                     progress.warn(&format!("Unable to get or insert local counterpart calendar for {} ({}). Skipping this time", cal_url, err));
                     continue;
-                },
+                }
                 Ok(arc) => arc,
             };
 
             if let Err(err) = Self::sync_calendar_pair(counterpart, cal_remote, progress).await {
-                progress.warn(&format!("Unable to sync calendar {}: {}, skipping this time.", cal_url, err));
+                progress.warn(&format!(
+                    "Unable to sync calendar {}: {}, skipping this time.",
+                    cal_url, err
+                ));
                 continue;
             }
             handled_calendars.insert(cal_url);
@@ -152,16 +168,22 @@ where
                 continue;
             }
 
-            let counterpart = match self.get_or_insert_remote_counterpart_calendar(&cal_url, cal_local.clone()).await {
+            let counterpart = match self
+                .get_or_insert_remote_counterpart_calendar(&cal_url, cal_local.clone())
+                .await
+            {
                 Err(err) => {
                     progress.warn(&format!("Unable to get or insert remote counterpart calendar for {} ({}). Skipping this time", cal_url, err));
                     continue;
-                },
+                }
                 Ok(arc) => arc,
             };
 
             if let Err(err) = Self::sync_calendar_pair(cal_local, counterpart, progress).await {
-                progress.warn(&format!("Unable to sync calendar {}: {}, skipping this time.", cal_url, err));
+                progress.warn(&format!(
+                    "Unable to sync calendar {}: {}, skipping this time.",
+                    cal_url, err
+                ));
                 continue;
             }
         }
@@ -171,26 +193,36 @@ where
         Ok(())
     }
 
-
-    async fn get_or_insert_local_counterpart_calendar(&mut self, cal_url: &Url, needle: Arc<Mutex<U>>) -> Result<Arc<Mutex<T>>, Box<dyn Error>> {
+    async fn get_or_insert_local_counterpart_calendar(
+        &mut self,
+        cal_url: &Url,
+        needle: Arc<Mutex<U>>,
+    ) -> Result<Arc<Mutex<T>>, Box<dyn Error>> {
         get_or_insert_counterpart_calendar("local", &mut self.local, cal_url, needle).await
     }
-    async fn get_or_insert_remote_counterpart_calendar(&mut self, cal_url: &Url, needle: Arc<Mutex<T>>) -> Result<Arc<Mutex<U>>, Box<dyn Error>> {
+    async fn get_or_insert_remote_counterpart_calendar(
+        &mut self,
+        cal_url: &Url,
+        needle: Arc<Mutex<T>>,
+    ) -> Result<Arc<Mutex<U>>, Box<dyn Error>> {
         get_or_insert_counterpart_calendar("remote", &mut self.remote, cal_url, needle).await
     }
 
-
-    async fn sync_calendar_pair(cal_local: Arc<Mutex<T>>, cal_remote: Arc<Mutex<U>>, progress: &mut SyncProgress) -> Result<(), Box<dyn Error>> {
+    async fn sync_calendar_pair(
+        cal_local: Arc<Mutex<T>>,
+        cal_remote: Arc<Mutex<U>>,
+        progress: &mut SyncProgress,
+    ) -> Result<(), Box<dyn Error>> {
         let mut cal_remote = cal_remote.lock().unwrap();
         let mut cal_local = cal_local.lock().unwrap();
         let cal_name = cal_local.name().to_string();
 
         progress.info(&format!("Syncing calendar {}", cal_name));
         progress.reset_counter();
-        progress.feedback(SyncEvent::InProgress{
+        progress.feedback(SyncEvent::InProgress {
             calendar: cal_name.clone(),
             items_done_already: 0,
-            details: "started".to_string()
+            details: "started".to_string(),
         });
 
         // Step 1 - find the differences
@@ -203,7 +235,7 @@ where
         let mut remote_additions = HashSet::new();
 
         let remote_items = cal_remote.get_item_version_tags().await?;
-        progress.feedback(SyncEvent::InProgress{
+        progress.feedback(SyncEvent::InProgress {
             calendar: cal_name.clone(),
             items_done_already: 0,
             details: format!("{} remote items", remote_items.len()),
@@ -217,24 +249,27 @@ where
                     // This was created on the remote
                     progress.debug(&format!("*   {} is a remote addition", url));
                     remote_additions.insert(url);
-                },
+                }
                 Some(local_item) => {
                     if local_items_to_handle.remove(&url) == false {
-                        progress.error(&format!("Inconsistent state: missing task {} from the local tasks", url));
+                        progress.error(&format!(
+                            "Inconsistent state: missing task {} from the local tasks",
+                            url
+                        ));
                     }
 
                     match local_item.sync_status() {
                         SyncStatus::NotSynced => {
                             progress.error(&format!("URL reuse between remote and local sources ({}). Ignoring this item in the sync", url));
                             continue;
-                        },
+                        }
                         SyncStatus::Synced(local_tag) => {
                             if &remote_tag != local_tag {
                                 // This has been modified on the remote
                                 progress.debug(&format!("*   {} is a remote change", url));
                                 remote_changes.insert(url);
                             }
-                        },
+                        }
                         SyncStatus::LocallyModified(local_tag) => {
                             if &remote_tag == local_tag {
                                 // This has been changed locally
@@ -242,10 +277,11 @@ where
                                 local_changes.insert(url);
                             } else {
                                 progress.info(&format!("Conflict: task {} has been modified in both sources. Using the remote version.", url));
-                                progress.debug(&format!("*   {} is considered a remote change", url));
+                                progress
+                                    .debug(&format!("*   {} is considered a remote change", url));
                                 remote_changes.insert(url);
                             }
-                        },
+                        }
                         SyncStatus::LocallyDeleted(local_tag) => {
                             if &remote_tag == local_tag {
                                 // This has been locally deleted
@@ -253,10 +289,11 @@ where
                                 local_del.insert(url);
                             } else {
                                 progress.info(&format!("Conflict: task {} has been locally deleted and remotely modified. Reverting to the remote version.", url));
-                                progress.debug(&format!("*   {} is a considered a remote change", url));
+                                progress
+                                    .debug(&format!("*   {} is a considered a remote change", url));
                                 remote_changes.insert(url);
                             }
-                        },
+                        }
                     }
                 }
             }
@@ -267,9 +304,12 @@ where
             progress.trace(&format!("##### Considering local item {}...", url));
             let local_item = match cal_local.get_item_by_url(&url).await {
                 None => {
-                    progress.error(&format!("Inconsistent state: missing task {} from the local tasks", url));
+                    progress.error(&format!(
+                        "Inconsistent state: missing task {} from the local tasks",
+                        url
+                    ));
                     continue;
-                },
+                }
                 Some(item) => item,
             };
 
@@ -278,31 +318,33 @@ where
                     // This item has been removed from the remote
                     progress.debug(&format!("#   {} is a deletion from the server", url));
                     remote_del.insert(url);
-                },
+                }
                 SyncStatus::NotSynced => {
                     // This item has just been locally created
                     progress.debug(&format!("#   {} has been locally created", url));
                     local_additions.insert(url);
-                },
+                }
                 SyncStatus::LocallyDeleted(_) => {
                     // This item has been deleted from both sources
                     progress.debug(&format!("#   {} has been deleted from both sources", url));
                     remote_del.insert(url);
-                },
+                }
                 SyncStatus::LocallyModified(_) => {
                     progress.info(&format!("Conflict: item {} has been deleted from the server and locally modified. Deleting the local copy", url));
                     remote_del.insert(url);
-                },
+                }
             }
         }
-
 
         // Step 2 - commit changes
         progress.trace("Committing changes...");
         for url_del in local_del {
-            progress.debug(&format!("> Pushing local deletion {} to the server", url_del));
+            progress.debug(&format!(
+                "> Pushing local deletion {} to the server",
+                url_del
+            ));
             progress.increment_counter(1);
-            progress.feedback(SyncEvent::InProgress{
+            progress.feedback(SyncEvent::InProgress {
                 calendar: cal_name.clone(),
                 items_done_already: progress.counter(),
                 details: Self::item_name(&cal_local, &url_del).await,
@@ -310,21 +352,27 @@ where
 
             match cal_remote.delete_item(&url_del).await {
                 Err(err) => {
-                    progress.warn(&format!("Unable to delete remote item {}: {}", url_del, err));
-                },
+                    progress.warn(&format!(
+                        "Unable to delete remote item {}: {}",
+                        url_del, err
+                    ));
+                }
                 Ok(()) => {
                     // Change the local copy from "marked to deletion" to "actually deleted"
                     if let Err(err) = cal_local.immediately_delete_item(&url_del).await {
-                        progress.error(&format!("Unable to permanently delete local item {}: {}", url_del, err));
+                        progress.error(&format!(
+                            "Unable to permanently delete local item {}: {}",
+                            url_del, err
+                        ));
                     }
-                },
+                }
             }
         }
 
         for url_del in remote_del {
             progress.debug(&format!("> Applying remote deletion {} locally", url_del));
             progress.increment_counter(1);
-            progress.feedback(SyncEvent::InProgress{
+            progress.feedback(SyncEvent::InProgress {
                 calendar: cal_name.clone(),
                 items_done_already: progress.counter(),
                 details: Self::item_name(&cal_local, &url_del).await,
@@ -339,22 +387,26 @@ where
             &mut *cal_local,
             &mut *cal_remote,
             progress,
-            &cal_name
-        ).await;
+            &cal_name,
+        )
+        .await;
 
         Self::apply_remote_changes(
             remote_changes,
             &mut *cal_local,
             &mut *cal_remote,
             progress,
-            &cal_name
-        ).await;
-
+            &cal_name,
+        )
+        .await;
 
         for url_add in local_additions {
-            progress.debug(&format!("> Pushing local addition {} to the server", url_add));
+            progress.debug(&format!(
+                "> Pushing local addition {} to the server",
+                url_add
+            ));
             progress.increment_counter(1);
-            progress.feedback(SyncEvent::InProgress{
+            progress.feedback(SyncEvent::InProgress {
                 calendar: cal_name.clone(),
                 items_done_already: progress.counter(),
                 details: Self::item_name(&cal_local, &url_add).await,
@@ -363,23 +415,29 @@ where
                 None => {
                     progress.error(&format!("Inconsistency: created item {} has been marked for upload but is locally missing", url_add));
                     continue;
-                },
+                }
                 Some(item) => {
                     match cal_remote.add_item(item.clone()).await {
-                        Err(err) => progress.error(&format!("Unable to add item {} to remote calendar: {}", url_add, err)),
+                        Err(err) => progress.error(&format!(
+                            "Unable to add item {} to remote calendar: {}",
+                            url_add, err
+                        )),
                         Ok(new_ss) => {
                             // Update local sync status
                             item.set_sync_status(new_ss);
-                        },
+                        }
                     }
-                },
+                }
             };
         }
 
         for url_change in local_changes {
-            progress.debug(&format!("> Pushing local change {} to the server", url_change));
+            progress.debug(&format!(
+                "> Pushing local change {} to the server",
+                url_change
+            ));
             progress.increment_counter(1);
-            progress.feedback(SyncEvent::InProgress{
+            progress.feedback(SyncEvent::InProgress {
                 calendar: cal_name.clone(),
                 items_done_already: progress.counter(),
                 details: Self::item_name(&cal_local, &url_change).await,
@@ -388,14 +446,17 @@ where
                 None => {
                     progress.error(&format!("Inconsistency: modified item {} has been marked for upload but is locally missing", url_change));
                     continue;
-                },
+                }
                 Some(item) => {
                     match cal_remote.update_item(item.clone()).await {
-                        Err(err) => progress.error(&format!("Unable to update item {} in remote calendar: {}", url_change, err)),
+                        Err(err) => progress.error(&format!(
+                            "Unable to update item {} in remote calendar: {}",
+                            url_change, err
+                        )),
                         Ok(new_ss) => {
                             // Update local sync status
                             item.set_sync_status(new_ss);
-                        },
+                        }
                     };
                 }
             };
@@ -404,9 +465,12 @@ where
         Ok(())
     }
 
-
     async fn item_name(cal: &T, url: &Url) -> String {
-        cal.get_item_by_url(url).await.map(|item| item.name()).unwrap_or_default().to_string()
+        cal.get_item_by_url(url)
+            .await
+            .map(|item| item.name())
+            .unwrap_or_default()
+            .to_string()
     }
 
     async fn apply_remote_additions(
@@ -414,10 +478,22 @@ where
         cal_local: &mut T,
         cal_remote: &mut U,
         progress: &mut SyncProgress,
-        cal_name: &str
+        cal_name: &str,
     ) {
-        for batch in remote_additions.drain().chunks(DOWNLOAD_BATCH_SIZE).into_iter() {
-            Self::fetch_batch_and_apply(BatchDownloadType::RemoteAdditions, batch, cal_local, cal_remote, progress, cal_name).await;
+        for batch in remote_additions
+            .drain()
+            .chunks(DOWNLOAD_BATCH_SIZE)
+            .into_iter()
+        {
+            Self::fetch_batch_and_apply(
+                BatchDownloadType::RemoteAdditions,
+                batch,
+                cal_local,
+                cal_remote,
+                progress,
+                cal_name,
+            )
+            .await;
         }
     }
 
@@ -426,10 +502,22 @@ where
         cal_local: &mut T,
         cal_remote: &mut U,
         progress: &mut SyncProgress,
-        cal_name: &str
+        cal_name: &str,
     ) {
-        for batch in remote_changes.drain().chunks(DOWNLOAD_BATCH_SIZE).into_iter() {
-            Self::fetch_batch_and_apply(BatchDownloadType::RemoteChanges, batch, cal_local, cal_remote, progress, cal_name).await;
+        for batch in remote_changes
+            .drain()
+            .chunks(DOWNLOAD_BATCH_SIZE)
+            .into_iter()
+        {
+            Self::fetch_batch_and_apply(
+                BatchDownloadType::RemoteChanges,
+                batch,
+                cal_local,
+                cal_remote,
+                progress,
+                cal_name,
+            )
+            .await;
         }
     }
 
@@ -439,31 +527,42 @@ where
         cal_local: &mut T,
         cal_remote: &mut U,
         progress: &mut SyncProgress,
-        cal_name: &str
+        cal_name: &str,
     ) {
         progress.debug(&format!("> Applying a batch of {} locally", batch_type) /* too bad Chunks does not implement ExactSizeIterator, that could provide useful debug info. See https://github.com/rust-itertools/itertools/issues/171 */);
 
         let list_of_additions: Vec<Url> = remote_additions.map(|url| url.clone()).collect();
         match cal_remote.get_items_by_url(&list_of_additions).await {
             Err(err) => {
-                progress.warn(&format!("Unable to get the batch of {} {:?}: {}. Skipping them.", batch_type, list_of_additions, err));
-            },
+                progress.warn(&format!(
+                    "Unable to get the batch of {} {:?}: {}. Skipping them.",
+                    batch_type, list_of_additions, err
+                ));
+            }
             Ok(items) => {
                 for item in items {
                     match item {
                         None => {
                             progress.error(&format!("Inconsistency: an item from the batch has vanished from the remote end"));
                             continue;
-                        },
+                        }
                         Some(new_item) => {
                             let local_update_result = match batch_type {
-                                BatchDownloadType::RemoteAdditions => cal_local.add_item(new_item.clone()).await,
-                                BatchDownloadType::RemoteChanges => cal_local.update_item(new_item.clone()).await,
+                                BatchDownloadType::RemoteAdditions => {
+                                    cal_local.add_item(new_item.clone()).await
+                                }
+                                BatchDownloadType::RemoteChanges => {
+                                    cal_local.update_item(new_item.clone()).await
+                                }
                             };
                             if let Err(err) = local_update_result {
-                                progress.error(&format!("Not able to add item {} to local calendar: {}", new_item.url(), err));
+                                progress.error(&format!(
+                                    "Not able to add item {} to local calendar: {}",
+                                    new_item.url(),
+                                    err
+                                ));
                             }
-                        },
+                        }
                     }
                 }
 
@@ -473,19 +572,22 @@ where
                     None => String::from("<unable to get the name of the first batched item>"),
                 };
                 progress.increment_counter(list_of_additions.len());
-                progress.feedback(SyncEvent::InProgress{
+                progress.feedback(SyncEvent::InProgress {
                     calendar: cal_name.to_string(),
                     items_done_already: progress.counter(),
                     details: one_item_name,
                 });
-            },
+            }
         }
     }
 }
 
-
-async fn get_or_insert_counterpart_calendar<H, N, I>(haystack_descr: &str, haystack: &mut H, cal_url: &Url, needle: Arc<Mutex<N>>)
-    -> Result<Arc<Mutex<I>>, Box<dyn Error>>
+async fn get_or_insert_counterpart_calendar<H, N, I>(
+    haystack_descr: &str,
+    haystack: &mut H,
+    cal_url: &Url,
+    needle: Arc<Mutex<N>>,
+) -> Result<Arc<Mutex<I>>, Box<dyn Error>>
 where
     H: CalDavSource<I>,
     I: BaseCalendar,
@@ -502,14 +604,11 @@ where
         let name = src.name().to_string();
         let supported_comps = src.supported_components();
         let color = src.color();
-        if let Err(err) = haystack.create_calendar(
-            cal_url.clone(),
-            name,
-            supported_comps,
-            color.cloned(),
-        ).await{
+        if let Err(err) = haystack
+            .create_calendar(cal_url.clone(), name, supported_comps, color.cloned())
+            .await
+        {
             return Err(err);
         }
     }
 }
-

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -3,7 +3,6 @@
 //! It is also responsible for syncing them together
 
 use std::collections::HashSet;
-use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
@@ -11,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use itertools::Itertools;
 use url::Url;
 
+use crate::error::KFResult;
 use crate::item::SyncStatus;
 use crate::traits::CompleteCalendar;
 use crate::traits::{BaseCalendar, CalDavSource, DavCalendar};
@@ -131,7 +131,7 @@ where
         progress.is_success()
     }
 
-    async fn run_sync_inner(&mut self, progress: &mut SyncProgress) -> Result<(), Box<dyn Error>> {
+    async fn run_sync_inner(&mut self, progress: &mut SyncProgress) -> KFResult<()> {
         progress.info("Starting a sync.");
         progress.feedback(SyncEvent::Started);
 
@@ -197,14 +197,14 @@ where
         &mut self,
         cal_url: &Url,
         needle: Arc<Mutex<U>>,
-    ) -> Result<Arc<Mutex<T>>, Box<dyn Error>> {
+    ) -> KFResult<Arc<Mutex<T>>> {
         get_or_insert_counterpart_calendar("local", &mut self.local, cal_url, needle).await
     }
     async fn get_or_insert_remote_counterpart_calendar(
         &mut self,
         cal_url: &Url,
         needle: Arc<Mutex<T>>,
-    ) -> Result<Arc<Mutex<U>>, Box<dyn Error>> {
+    ) -> KFResult<Arc<Mutex<U>>> {
         get_or_insert_counterpart_calendar("remote", &mut self.remote, cal_url, needle).await
     }
 
@@ -212,7 +212,7 @@ where
         cal_local: Arc<Mutex<T>>,
         cal_remote: Arc<Mutex<U>>,
         progress: &mut SyncProgress,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> KFResult<()> {
         let mut cal_remote = cal_remote.lock().unwrap();
         let mut cal_local = cal_local.lock().unwrap();
         let cal_name = cal_local.name().to_string();
@@ -587,7 +587,7 @@ async fn get_or_insert_counterpart_calendar<H, N, I>(
     haystack: &mut H,
     cal_url: &Url,
     needle: Arc<Mutex<N>>,
-) -> Result<Arc<Mutex<I>>, Box<dyn Error>>
+) -> KFResult<Arc<Mutex<I>>>
 where
     H: CalDavSource<I>,
     I: BaseCalendar,

--- a/src/provider/sync_progress.rs
+++ b/src/provider/sync_progress.rs
@@ -10,9 +10,13 @@ pub enum SyncEvent {
     /// Sync has just started but no calendar is handled yet
     Started,
     /// Sync is in progress.
-    InProgress{ calendar: String, items_done_already: usize, details: String},
+    InProgress {
+        calendar: String,
+        items_done_already: usize,
+        details: String,
+    },
     /// Sync is finished
-    Finished{ success: bool },
+    Finished { success: bool },
 }
 
 impl Display for SyncEvent {
@@ -20,11 +24,15 @@ impl Display for SyncEvent {
         match self {
             SyncEvent::NotStarted => write!(f, "Not started"),
             SyncEvent::Started => write!(f, "Sync has started..."),
-            SyncEvent::InProgress{calendar, items_done_already, details} => write!(f, "{} [{}/?] {}...", calendar, items_done_already, details),
-            SyncEvent::Finished{success} => match success {
+            SyncEvent::InProgress {
+                calendar,
+                items_done_already,
+                details,
+            } => write!(f, "{} [{}/?] {}...", calendar, items_done_already, details),
+            SyncEvent::Finished { success } => match success {
                 true => write!(f, "Sync successfully finished"),
                 false => write!(f, "Sync finished with errors"),
-            }
+            },
         }
     }
 }
@@ -34,8 +42,6 @@ impl Default for SyncEvent {
         Self::NotStarted
     }
 }
-
-
 
 /// See [`feedback_channel`]
 pub type FeedbackSender = tokio::sync::watch::Sender<SyncEvent>;
@@ -47,9 +53,6 @@ pub fn feedback_channel() -> (FeedbackSender, FeedbackReceiver) {
     tokio::sync::watch::channel(SyncEvent::default())
 }
 
-
-
-
 /// A structure that tracks the progression and the errors that happen during a sync
 pub struct SyncProgress {
     n_errors: u32,
@@ -58,10 +61,18 @@ pub struct SyncProgress {
 }
 impl SyncProgress {
     pub fn new() -> Self {
-        Self { n_errors: 0, feedback_channel: None, counter: 0 }
+        Self {
+            n_errors: 0,
+            feedback_channel: None,
+            counter: 0,
+        }
     }
     pub fn new_with_feedback_channel(channel: FeedbackSender) -> Self {
-        Self { n_errors: 0, feedback_channel: Some(channel), counter: 0 }
+        Self {
+            n_errors: 0,
+            feedback_channel: Some(channel),
+            counter: 0,
+        }
     }
 
     /// Reset the user-info counter
@@ -78,8 +89,6 @@ impl SyncProgress {
     pub fn counter(&self) -> usize {
         self.counter
     }
-
-
 
     pub fn is_success(&self) -> bool {
         self.n_errors == 0
@@ -111,8 +120,6 @@ impl SyncProgress {
     pub fn feedback(&mut self, event: SyncEvent) {
         self.feedback_channel
             .as_ref()
-            .map(|sender| {
-                sender.send(event)
-            });
+            .map(|sender| sender.send(event));
     }
 }

--- a/src/provider/sync_progress.rs
+++ b/src/provider/sync_progress.rs
@@ -123,3 +123,9 @@ impl SyncProgress {
             .map(|sender| sender.send(event));
     }
 }
+
+impl Default for SyncProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -10,12 +10,22 @@ pub struct Resource {
 
 impl Resource {
     pub fn new(url: Url, username: String, password: String) -> Self {
-        Self { url, username, password }
+        Self {
+            url,
+            username,
+            password,
+        }
     }
 
-    pub fn url(&self) -> &Url { &self.url }
-    pub fn username(&self) -> &String { &self.username }
-    pub fn password(&self) -> &String { &self.password }
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+    pub fn username(&self) -> &String {
+        &self.username
+    }
+    pub fn password(&self) -> &String {
+        &self.password
+    }
 
     /// Build a new Resource by keeping the same credentials, scheme and server from `base` but changing the path part
     pub fn combine(&self, new_path: &str) -> Resource {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -30,7 +30,7 @@ impl Resource {
     /// Build a new Resource by keeping the same credentials, scheme and server from `base` but changing the path part
     pub fn combine(&self, new_path: &str) -> Resource {
         let mut built = (*self).clone();
-        built.url.set_path(&new_path);
+        built.url.set_path(new_path);
         built
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,10 +1,10 @@
 //! To-do tasks (iCal `VTODO` item)
 
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 use chrono::{DateTime, Utc};
 use ical::property::Property;
+use serde::{Deserialize, Serialize};
 use url::Url;
+use uuid::Uuid;
 
 use crate::item::SyncStatus;
 use crate::utils::random_url;
@@ -53,7 +53,6 @@ pub struct Task {
     /// The display name of the task
     name: String,
 
-
     /// The PRODID, as defined in iCal files
     ical_prod_id: String,
 
@@ -61,7 +60,6 @@ pub struct Task {
     /// They are needed to serialize this item into an equivalent iCal file
     extra_parameters: Vec<Property>,
 }
-
 
 impl Task {
     /// Create a brand new Task that is not on a server yet.
@@ -73,20 +71,37 @@ impl Task {
         let new_creation_date = Some(Utc::now());
         let new_last_modified = Utc::now();
         let new_completion_status = if completed {
-                CompletionStatus::Completed(Some(Utc::now()))
-            } else { CompletionStatus::Uncompleted };
+            CompletionStatus::Completed(Some(Utc::now()))
+        } else {
+            CompletionStatus::Uncompleted
+        };
         let ical_prod_id = crate::ical::default_prod_id();
         let extra_parameters = Vec::new();
-        Self::new_with_parameters(name, new_uid, new_url, new_completion_status, new_sync_status, new_creation_date, new_last_modified, ical_prod_id, extra_parameters)
+        Self::new_with_parameters(
+            name,
+            new_uid,
+            new_url,
+            new_completion_status,
+            new_sync_status,
+            new_creation_date,
+            new_last_modified,
+            ical_prod_id,
+            extra_parameters,
+        )
     }
 
     /// Create a new Task instance, that may be synced on the server already
-    pub fn new_with_parameters(name: String, uid: String, new_url: Url,
-                               completion_status: CompletionStatus,
-                               sync_status: SyncStatus, creation_date: Option<DateTime<Utc>>, last_modified: DateTime<Utc>,
-                               ical_prod_id: String, extra_parameters: Vec<Property>,
-                            ) -> Self
-    {
+    pub fn new_with_parameters(
+        name: String,
+        uid: String,
+        new_url: Url,
+        completion_status: CompletionStatus,
+        sync_status: SyncStatus,
+        creation_date: Option<DateTime<Utc>>,
+        last_modified: DateTime<Utc>,
+        ical_prod_id: String,
+        extra_parameters: Vec<Property>,
+    ) -> Self {
         Self {
             url: new_url,
             uid,
@@ -100,20 +115,40 @@ impl Task {
         }
     }
 
-    pub fn url(&self) -> &Url       { &self.url         }
-    pub fn uid(&self) -> &str       { &self.uid         }
-    pub fn name(&self) -> &str      { &self.name        }
-    pub fn completed(&self) -> bool { self.completion_status.is_completed() }
-    pub fn ical_prod_id(&self) -> &str            { &self.ical_prod_id }
-    pub fn sync_status(&self) -> &SyncStatus      { &self.sync_status  }
-    pub fn last_modified(&self) -> &DateTime<Utc> { &self.last_modified }
-    pub fn creation_date(&self) -> Option<&DateTime<Utc>>   { self.creation_date.as_ref() }
-    pub fn completion_status(&self) -> &CompletionStatus    { &self.completion_status }
-    pub fn extra_parameters(&self) -> &[Property]           { &self.extra_parameters }
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+    pub fn uid(&self) -> &str {
+        &self.uid
+    }
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn completed(&self) -> bool {
+        self.completion_status.is_completed()
+    }
+    pub fn ical_prod_id(&self) -> &str {
+        &self.ical_prod_id
+    }
+    pub fn sync_status(&self) -> &SyncStatus {
+        &self.sync_status
+    }
+    pub fn last_modified(&self) -> &DateTime<Utc> {
+        &self.last_modified
+    }
+    pub fn creation_date(&self) -> Option<&DateTime<Utc>> {
+        self.creation_date.as_ref()
+    }
+    pub fn completion_status(&self) -> &CompletionStatus {
+        &self.completion_status
+    }
+    pub fn extra_parameters(&self) -> &[Property] {
+        &self.extra_parameters
+    }
 
     #[cfg(any(test, feature = "integration_tests"))]
     pub fn has_same_observable_content_as(&self, other: &Task) -> bool {
-           self.url == other.url
+        self.url == other.url
         && self.uid == other.uid
         && self.name == other.name
         // sync status must be the same variant, but we ignore its embedded version tag
@@ -137,14 +172,13 @@ impl Task {
             SyncStatus::LocallyDeleted(_) => {
                 log::warn!("Trying to update an item that has previously been deleted. These changes will probably be ignored at next sync.");
                 return;
-            },
+            }
         }
     }
 
     fn update_last_modified(&mut self) {
         self.last_modified = Utc::now();
     }
-
 
     /// Rename a task.
     /// This updates its "last modified" field
@@ -169,7 +203,10 @@ impl Task {
     }
     #[cfg(feature = "local_calendar_mocks_remote_calendars")]
     /// Set the completion status, but forces a "master" SyncStatus, just like CalDAV servers are always "masters"
-    pub fn mock_remote_calendar_set_completion_status(&mut self, new_completion_status: CompletionStatus) {
+    pub fn mock_remote_calendar_set_completion_status(
+        &mut self,
+        new_completion_status: CompletionStatus,
+    ) {
         self.sync_status = SyncStatus::random_synced();
         self.completion_status = new_completion_status;
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -14,6 +14,7 @@ use crate::utils::random_url;
 ///
 /// * `COMPLETED` is an optional timestamp that tells whether this task is completed
 /// * `STATUS` is an optional field, that can be set to `NEEDS-ACTION`, `COMPLETED`, or others.
+///
 /// Even though having a `COMPLETED` date but a `STATUS:NEEDS-ACTION` is theorically possible, it obviously makes no sense. This API ensures this cannot happen
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum CompletionStatus {
@@ -22,10 +23,7 @@ pub enum CompletionStatus {
 }
 impl CompletionStatus {
     pub fn is_completed(&self) -> bool {
-        match self {
-            CompletionStatus::Completed(_) => true,
-            _ => false,
-        }
+        matches!(self, CompletionStatus::Completed(_))
     }
 }
 
@@ -164,14 +162,12 @@ impl Task {
 
     fn update_sync_status(&mut self) {
         match &self.sync_status {
-            SyncStatus::NotSynced => return,
-            SyncStatus::LocallyModified(_) => return,
+            SyncStatus::NotSynced | SyncStatus::LocallyModified(_) => { /* do nothing */ }
             SyncStatus::Synced(prev_vt) => {
                 self.sync_status = SyncStatus::LocallyModified(prev_vt.clone());
             }
             SyncStatus::LocallyDeleted(_) => {
                 log::warn!("Trying to update an item that has previously been deleted. These changes will probably be ignored at next sync.");
-                return;
             }
         }
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,17 +1,17 @@
 //! Traits used by multiple structs in this crate
 
-use std::error::Error;
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use csscolorparser::Color;
 use url::Url;
 
-use crate::item::SyncStatus;
-use crate::item::Item;
-use crate::item::VersionTag;
 use crate::calendar::SupportedComponents;
+use crate::item::Item;
+use crate::item::SyncStatus;
+use crate::item::VersionTag;
 use crate::resource::Resource;
 
 /// This trait must be implemented by data sources (either local caches or remote CalDAV clients)
@@ -25,8 +25,13 @@ pub trait CalDavSource<T: BaseCalendar> {
     /// Returns the calendar matching the URL
     async fn get_calendar(&self, url: &Url) -> Option<Arc<Mutex<T>>>;
     /// Create a calendar if it did not exist, and return it
-    async fn create_calendar(&mut self, url: Url, name: String, supported_components: SupportedComponents, color: Option<Color>)
-        -> Result<Arc<Mutex<T>>, Box<dyn Error>>;
+    async fn create_calendar(
+        &mut self,
+        url: Url,
+        name: String,
+        supported_components: SupportedComponents,
+        color: Option<Color>,
+    ) -> Result<Arc<Mutex<T>>, Box<dyn Error>>;
 
     // Removing a calendar is not supported yet
 }
@@ -59,23 +64,29 @@ pub trait BaseCalendar {
 
     /// Returns whether this calDAV calendar supports to-do items
     fn supports_todo(&self) -> bool {
-        self.supported_components().contains(crate::calendar::SupportedComponents::TODO)
+        self.supported_components()
+            .contains(crate::calendar::SupportedComponents::TODO)
     }
 
     /// Returns whether this calDAV calendar supports calendar items
     fn supports_events(&self) -> bool {
-        self.supported_components().contains(crate::calendar::SupportedComponents::EVENT)
+        self.supported_components()
+            .contains(crate::calendar::SupportedComponents::EVENT)
     }
 }
-
 
 /// Functions availabe for calendars that are backed by a CalDAV server
 ///
 /// Note that some concrete types (e.g. [`crate::calendar::cached_calendar::CachedCalendar`]) can also provide non-async versions of these functions
 #[async_trait]
-pub trait DavCalendar : BaseCalendar {
+pub trait DavCalendar: BaseCalendar {
     /// Create a new calendar
-    fn new(name: String, resource: Resource, supported_components: SupportedComponents, color: Option<Color>) -> Self;
+    fn new(
+        name: String,
+        resource: Resource,
+        supported_components: SupportedComponents,
+        color: Option<Color>,
+    ) -> Self;
 
     /// Get the URLs and the version tags of every item in this calendar
     async fn get_item_version_tags(&self) -> Result<HashMap<Url, VersionTag>, Box<dyn Error>>;
@@ -93,15 +104,12 @@ pub trait DavCalendar : BaseCalendar {
     /// Get the URLs of all current items in this calendar
     async fn get_item_urls(&self) -> Result<HashSet<Url>, Box<dyn Error>> {
         let items = self.get_item_version_tags().await?;
-        Ok(items.iter()
-            .map(|(url, _tag)| url.clone())
-            .collect())
+        Ok(items.iter().map(|(url, _tag)| url.clone()).collect())
     }
 
     // Note: the CalDAV protocol could also enable to do this:
     // fn get_current_version(&self) -> CTag
 }
-
 
 /// Functions availabe for calendars we have full knowledge of
 ///
@@ -109,9 +117,14 @@ pub trait DavCalendar : BaseCalendar {
 ///
 /// Note that some concrete types (e.g. [`crate::calendar::cached_calendar::CachedCalendar`]) can also provide non-async versions of these functions
 #[async_trait]
-pub trait CompleteCalendar : BaseCalendar {
+pub trait CompleteCalendar: BaseCalendar {
     /// Create a new calendar
-    fn new(name: String, url: Url, supported_components: SupportedComponents, color: Option<Color>) -> Self;
+    fn new(
+        name: String,
+        url: Url,
+        supported_components: SupportedComponents,
+        color: Option<Color>,
+    ) -> Self;
 
     /// Get the URLs of all current items in this calendar
     async fn get_item_urls(&self) -> Result<HashSet<Url>, Box<dyn Error>>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -97,7 +97,7 @@ pub trait DavCalendar: BaseCalendar {
 
     /// Returns a set of items.
     /// This is usually faster than calling multiple consecutive [`DavCalendar::get_item_by_url`], since it only issues one HTTP request.
-    async fn get_items_by_url(&self, urls: &[Url]) -> Result<Vec<Option<Item>>, Box<dyn Error>>;
+    async fn get_items_by_url(&self, urls: &[Url]) -> KFResult<Vec<Option<Item>>>;
 
     /// Delete an item
     async fn delete_item(&mut self, item_url: &Url) -> KFResult<()>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,6 @@
 //! Traits used by multiple structs in this crate
 
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -103,7 +103,7 @@ pub trait DavCalendar: BaseCalendar {
     async fn delete_item(&mut self, item_url: &Url) -> KFResult<()>;
 
     /// Get the URLs of all current items in this calendar
-    async fn get_item_urls(&self) -> Result<HashSet<Url>, Box<dyn Error>> {
+    async fn get_item_urls(&self) -> KFResult<HashSet<Url>> {
         let items = self.get_item_version_tags().await?;
         Ok(items.keys().cloned().collect())
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -104,7 +104,7 @@ pub trait DavCalendar: BaseCalendar {
     /// Get the URLs of all current items in this calendar
     async fn get_item_urls(&self) -> Result<HashSet<Url>, Box<dyn Error>> {
         let items = self.get_item_version_tags().await?;
-        Ok(items.iter().map(|(url, _tag)| url.clone()).collect())
+        Ok(items.keys().cloned().collect())
     }
 
     // Note: the CalDAV protocol could also enable to do this:

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,6 +9,7 @@ use csscolorparser::Color;
 use url::Url;
 
 use crate::calendar::SupportedComponents;
+use crate::error::KFError;
 use crate::item::Item;
 use crate::item::SyncStatus;
 use crate::item::VersionTag;
@@ -31,7 +32,7 @@ pub trait CalDavSource<T: BaseCalendar> {
         name: String,
         supported_components: SupportedComponents,
         color: Option<Color>,
-    ) -> Result<Arc<Mutex<T>>, Box<dyn Error>>;
+    ) -> Result<Arc<Mutex<T>>, KFError>;
 
     // Removing a calendar is not supported yet
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -90,7 +90,7 @@ pub trait DavCalendar: BaseCalendar {
     ) -> Self;
 
     /// Get the URLs and the version tags of every item in this calendar
-    async fn get_item_version_tags(&self) -> Result<HashMap<Url, VersionTag>, Box<dyn Error>>;
+    async fn get_item_version_tags(&self) -> KFResult<HashMap<Url, VersionTag>>;
 
     /// Returns a particular item
     async fn get_item_by_url(&self, url: &Url) -> Result<Option<Item>, Box<dyn Error>>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -93,7 +93,7 @@ pub trait DavCalendar: BaseCalendar {
     async fn get_item_version_tags(&self) -> KFResult<HashMap<Url, VersionTag>>;
 
     /// Returns a particular item
-    async fn get_item_by_url(&self, url: &Url) -> Result<Option<Item>, Box<dyn Error>>;
+    async fn get_item_by_url(&self, url: &Url) -> KFResult<Option<Item>>;
 
     /// Returns a set of items.
     /// This is usually faster than calling multiple consecutive [`DavCalendar::get_item_by_url`], since it only issues one HTTP request.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,17 +1,17 @@
 //! Some utility functions
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
 use std::hash::Hash;
 use std::io::{stdin, stdout, Read, Write};
+use std::sync::{Arc, Mutex};
 
 use minidom::Element;
 use url::Url;
 
+use crate::item::SyncStatus;
 use crate::traits::CompleteCalendar;
 use crate::traits::DavCalendar;
 use crate::Item;
-use crate::item::SyncStatus;
 
 /// Walks an XML tree and returns every element that has the given name
 pub fn find_elems<S: AsRef<str>>(root: &Element, searched_name: S) -> Vec<&Element> {
@@ -49,14 +49,10 @@ pub fn find_elem<S: AsRef<str>>(root: &Element, searched_name: S) -> Option<&Ele
     None
 }
 
-
 pub fn print_xml(element: &Element) {
     let mut writer = std::io::stdout();
 
-    let mut xml_writer = minidom::quick_xml::Writer::new_with_indent(
-        std::io::stdout(),
-        0x20, 4
-    );
+    let mut xml_writer = minidom::quick_xml::Writer::new_with_indent(std::io::stdout(), 0x20, 4);
     let _ = element.to_writer(&mut xml_writer);
     let _ = writer.write(&[0x0a]);
 }
@@ -74,7 +70,7 @@ where
                 for (_, item) in map {
                     print_task(item);
                 }
-            },
+            }
         }
     }
 }
@@ -92,7 +88,7 @@ where
                 for (url, version_tag) in map {
                     println!("    * {} (version {:?})", url, version_tag);
                 }
-            },
+            }
         }
     }
 }
@@ -105,14 +101,13 @@ pub fn print_task(item: &Item) {
                 SyncStatus::NotSynced => ".",
                 SyncStatus::Synced(_) => "=",
                 SyncStatus::LocallyModified(_) => "~",
-                SyncStatus::LocallyDeleted(_) =>  "x",
+                SyncStatus::LocallyDeleted(_) => "x",
             };
             println!("    {}{} {}\t{}", completion, sync, task.name(), task.url());
-        },
+        }
         _ => return,
     }
 }
-
 
 /// Compare keys of two hashmaps for equality
 pub fn keys_are_the_same<T, U, V>(left: &HashMap<T, U>, right: &HashMap<T, V>) -> bool
@@ -140,7 +135,6 @@ where
     result
 }
 
-
 /// Wait for the user to press enter
 pub fn pause() {
     let mut stdout = stdout();
@@ -148,7 +142,6 @@ pub fn pause() {
     stdout.flush().unwrap();
     stdin().read_exact(&mut [0]).unwrap();
 }
-
 
 /// Generate a random URL with a given prefix
 pub fn random_url(parent_calendar: &Url) -> Url {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -94,18 +94,15 @@ where
 }
 
 pub fn print_task(item: &Item) {
-    match item {
-        Item::Task(task) => {
-            let completion = if task.completed() { "✓" } else { " " };
-            let sync = match task.sync_status() {
-                SyncStatus::NotSynced => ".",
-                SyncStatus::Synced(_) => "=",
-                SyncStatus::LocallyModified(_) => "~",
-                SyncStatus::LocallyDeleted(_) => "x",
-            };
-            println!("    {}{} {}\t{}", completion, sync, task.name(), task.url());
-        }
-        _ => return,
+    if let Item::Task(task) = item {
+        let completion = if task.completed() { "✓" } else { " " };
+        let sync = match task.sync_status() {
+            SyncStatus::NotSynced => ".",
+            SyncStatus::Synced(_) => "=",
+            SyncStatus::LocallyModified(_) => "~",
+            SyncStatus::LocallyDeleted(_) => "x",
+        };
+        println!("    {}{} {}\t{}", completion, sync, task.name(), task.url());
     }
 }
 
@@ -122,7 +119,7 @@ where
     let keys_l: HashSet<T> = left.keys().cloned().collect();
     let keys_r: HashSet<T> = right.keys().cloned().collect();
     let result = keys_l == keys_r;
-    if result == false {
+    if !result {
         log::debug!("Keys of a map mismatch");
         for key in keys_l {
             log::debug!("   left: {}", key);

--- a/tests/scenarii.rs
+++ b/tests/scenarii.rs
@@ -8,27 +8,27 @@
 //! This module can also check the sources after a sync contain the actual data we expect
 #![cfg(feature = "local_calendar_mocks_remote_calendars")]
 
+use std::error::Error;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::error::Error;
 use url::Url;
 
 use chrono::Utc;
 
+use kitchen_fridge::cache::Cache;
+use kitchen_fridge::calendar::cached_calendar::CachedCalendar;
 use kitchen_fridge::calendar::SupportedComponents;
-use kitchen_fridge::traits::CalDavSource;
+use kitchen_fridge::item::SyncStatus;
+use kitchen_fridge::mock_behaviour::MockBehaviour;
+use kitchen_fridge::provider::Provider;
+use kitchen_fridge::task::CompletionStatus;
 use kitchen_fridge::traits::BaseCalendar;
+use kitchen_fridge::traits::CalDavSource;
 use kitchen_fridge::traits::CompleteCalendar;
 use kitchen_fridge::traits::DavCalendar;
-use kitchen_fridge::cache::Cache;
-use kitchen_fridge::Item;
-use kitchen_fridge::item::SyncStatus;
-use kitchen_fridge::Task;
-use kitchen_fridge::task::CompletionStatus;
-use kitchen_fridge::calendar::cached_calendar::CachedCalendar;
-use kitchen_fridge::provider::Provider;
-use kitchen_fridge::mock_behaviour::MockBehaviour;
 use kitchen_fridge::utils::random_url;
+use kitchen_fridge::Item;
+use kitchen_fridge::Task;
 
 pub enum LocatedState {
     /// Item does not exist yet or does not exist anymore
@@ -60,11 +60,10 @@ pub enum ChangeToApply {
     // ChangeCalendar(Url) is useless, as long as changing a calendar is implemented as "delete in one calendar and re-create it in another one"
 }
 
-
 pub struct ItemScenario {
     url: Url,
     initial_state: LocatedState,
-    local_changes_to_apply:  Vec<ChangeToApply>,
+    local_changes_to_apply: Vec<ChangeToApply>,
     remote_changes_to_apply: Vec<ChangeToApply>,
     after_sync: LocatedState,
 }
@@ -91,325 +90,313 @@ pub fn scenarii_basic() -> Vec<ItemScenario> {
     let second_cal = Url::from("https://some.calend.ar/calendar-2/".parse().unwrap());
     let third_cal = Url::from("https://some.calend.ar/calendar-3/".parse().unwrap());
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&first_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task A"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task A"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&first_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task A"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task A"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&first_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task B"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: vec![ChangeToApply::Remove],
-            after_sync: LocatedState::None,
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&first_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task B"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: vec![ChangeToApply::Remove],
+        after_sync: LocatedState::None,
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&first_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task C"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::Remove],
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::None,
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&first_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task C"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::Remove],
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::None,
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&first_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task D"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::Rename(String::from("Task D, locally renamed"))],
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task D, locally renamed"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&first_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task D"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::Rename(String::from(
+            "Task D, locally renamed",
+        ))],
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task D, locally renamed"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&first_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task E"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: vec![ChangeToApply::Rename(String::from("Task E, remotely renamed"))],
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task E, remotely renamed"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&first_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task E"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: vec![ChangeToApply::Rename(String::from(
+            "Task E, remotely renamed",
+        ))],
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task E, remotely renamed"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&first_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task F"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::Rename(String::from("Task F, locally renamed"))],
-            remote_changes_to_apply: vec![ChangeToApply::Rename(String::from("Task F, remotely renamed"))],
-            // Conflict: the server wins
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: first_cal.clone(),
-                name: String::from("Task F, remotely renamed"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&first_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task F"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::Rename(String::from(
+            "Task F, locally renamed",
+        ))],
+        remote_changes_to_apply: vec![ChangeToApply::Rename(String::from(
+            "Task F, remotely renamed",
+        ))],
+        // Conflict: the server wins
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: first_cal.clone(),
+            name: String::from("Task F, remotely renamed"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&second_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task G"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task G"),
-                completed: true,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&second_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task G"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task G"),
+            completed: true,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&second_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task H"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task H"),
-                completed: true,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&second_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task H"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task H"),
+            completed: true,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&second_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task I"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
-            remote_changes_to_apply: vec![ChangeToApply::Rename(String::from("Task I, remotely renamed"))],
-            // Conflict, the server wins
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task I, remotely renamed"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&second_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task I"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
+        remote_changes_to_apply: vec![ChangeToApply::Rename(String::from(
+            "Task I, remotely renamed",
+        ))],
+        // Conflict, the server wins
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task I, remotely renamed"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&second_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task J"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
-            remote_changes_to_apply: vec![ChangeToApply::Remove],
-            after_sync: LocatedState::None,
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&second_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task J"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
+        remote_changes_to_apply: vec![ChangeToApply::Remove],
+        after_sync: LocatedState::None,
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&second_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task K"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::Remove],
-            remote_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task K"),
-                completed: true,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&second_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task K"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::Remove],
+        remote_changes_to_apply: vec![ChangeToApply::SetCompletion(true)],
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task K"),
+            completed: true,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&second_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task L"),
-                completed: false,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::Remove],
-            remote_changes_to_apply: vec![ChangeToApply::Remove],
-            after_sync: LocatedState::None,
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&second_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task L"),
+            completed: false,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::Remove],
+        remote_changes_to_apply: vec![ChangeToApply::Remove],
+        after_sync: LocatedState::None,
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&second_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task M"),
-                completed: true,
-            }),
-            local_changes_to_apply: vec![ChangeToApply::SetCompletion(false)],
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: second_cal.clone(),
-                name: String::from("Task M"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&second_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task M"),
+            completed: true,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::SetCompletion(false)],
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: second_cal.clone(),
+            name: String::from("Task M"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&third_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task N"),
-                completed: true,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: vec![ChangeToApply::SetCompletion(false)],
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task N"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&third_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task N"),
+            completed: true,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: vec![ChangeToApply::SetCompletion(false)],
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task N"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&third_cal),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task O"),
-                completed: true,
-            }),
-            local_changes_to_apply:  vec![ChangeToApply::SetCompletion(false)],
-            remote_changes_to_apply: vec![ChangeToApply::SetCompletion(false)],
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task O"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&third_cal),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task O"),
+            completed: true,
+        }),
+        local_changes_to_apply: vec![ChangeToApply::SetCompletion(false)],
+        remote_changes_to_apply: vec![ChangeToApply::SetCompletion(false)],
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task O"),
+            completed: false,
+        }),
+    });
 
     let url_p = random_url(&third_cal);
-    tasks.push(
-        ItemScenario {
-            url: url_p.clone(),
-            initial_state: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task P"),
-                completed: true,
-            }),
-            local_changes_to_apply: vec![
-                ChangeToApply::Rename(String::from("Task P, locally renamed and un-completed")),
-                ChangeToApply::SetCompletion(false),
-            ],
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task P, locally renamed and un-completed"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: url_p.clone(),
+        initial_state: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task P"),
+            completed: true,
+        }),
+        local_changes_to_apply: vec![
+            ChangeToApply::Rename(String::from("Task P, locally renamed and un-completed")),
+            ChangeToApply::SetCompletion(false),
+        ],
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task P, locally renamed and un-completed"),
+            completed: false,
+        }),
+    });
 
     let url_q = random_url(&third_cal);
-    tasks.push(
-        ItemScenario {
-            url: url_q.clone(),
-            initial_state: LocatedState::None,
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: vec![ChangeToApply::Create(third_cal.clone(), Item::Task(
-                Task::new_with_parameters(
-                    String::from("Task Q, created on the server"),
-                    url_q.to_string(), url_q,
-                    CompletionStatus::Uncompleted,
-                    SyncStatus::random_synced(), Some(Utc::now()), Utc::now(), "prod_id".to_string(), Vec::new() )
-            ))],
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task Q, created on the server"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: url_q.clone(),
+        initial_state: LocatedState::None,
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: vec![ChangeToApply::Create(
+            third_cal.clone(),
+            Item::Task(Task::new_with_parameters(
+                String::from("Task Q, created on the server"),
+                url_q.to_string(),
+                url_q,
+                CompletionStatus::Uncompleted,
+                SyncStatus::random_synced(),
+                Some(Utc::now()),
+                Utc::now(),
+                "prod_id".to_string(),
+                Vec::new(),
+            )),
+        )],
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task Q, created on the server"),
+            completed: false,
+        }),
+    });
 
     let url_r = random_url(&third_cal);
-    tasks.push(
-        ItemScenario {
-            url: url_r.clone(),
-            initial_state: LocatedState::None,
-            local_changes_to_apply: vec![ChangeToApply::Create(third_cal.clone(), Item::Task(
-                Task::new_with_parameters(
-                    String::from("Task R, created locally"),
-                    url_r.to_string(), url_r,
-                    CompletionStatus::Uncompleted,
-                    SyncStatus::NotSynced, Some(Utc::now()), Utc::now(), "prod_id".to_string(), Vec::new() )
-            ))],
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: third_cal.clone(),
-                name: String::from("Task R, created locally"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: url_r.clone(),
+        initial_state: LocatedState::None,
+        local_changes_to_apply: vec![ChangeToApply::Create(
+            third_cal.clone(),
+            Item::Task(Task::new_with_parameters(
+                String::from("Task R, created locally"),
+                url_r.to_string(),
+                url_r,
+                CompletionStatus::Uncompleted,
+                SyncStatus::NotSynced,
+                Some(Utc::now()),
+                Utc::now(),
+                "prod_id".to_string(),
+                Vec::new(),
+            )),
+        )],
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: third_cal.clone(),
+            name: String::from("Task R, created locally"),
+            completed: false,
+        }),
+    });
 
     tasks
 }
@@ -421,59 +408,53 @@ pub fn scenarii_first_sync_to_local() -> Vec<ItemScenario> {
     let cal1 = Url::from("https://some.calend.ar/first/".parse().unwrap());
     let cal2 = Url::from("https://some.calend.ar/second/".parse().unwrap());
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&cal1),
-            initial_state: LocatedState::Remote( ItemState{
-                calendar: cal1.clone(),
-                name: String::from("Task A1"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: cal1.clone(),
-                name: String::from("Task A1"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&cal1),
+        initial_state: LocatedState::Remote(ItemState {
+            calendar: cal1.clone(),
+            name: String::from("Task A1"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: cal1.clone(),
+            name: String::from("Task A1"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&cal2),
-            initial_state: LocatedState::Remote( ItemState{
-                calendar: cal2.clone(),
-                name: String::from("Task A2"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: cal2.clone(),
-                name: String::from("Task A2"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&cal2),
+        initial_state: LocatedState::Remote(ItemState {
+            calendar: cal2.clone(),
+            name: String::from("Task A2"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: cal2.clone(),
+            name: String::from("Task A2"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&cal1),
-            initial_state: LocatedState::Remote( ItemState{
-                calendar: cal1.clone(),
-                name: String::from("Task B1"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: cal1.clone(),
-                name: String::from("Task B1"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&cal1),
+        initial_state: LocatedState::Remote(ItemState {
+            calendar: cal1.clone(),
+            name: String::from("Task B1"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: cal1.clone(),
+            name: String::from("Task B1"),
+            completed: false,
+        }),
+    });
 
     tasks
 }
@@ -485,63 +466,56 @@ pub fn scenarii_first_sync_to_server() -> Vec<ItemScenario> {
     let cal3 = Url::from("https://some.calend.ar/third/".parse().unwrap());
     let cal4 = Url::from("https://some.calend.ar/fourth/".parse().unwrap());
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&cal3),
-            initial_state: LocatedState::Local( ItemState{
-                calendar: cal3.clone(),
-                name: String::from("Task A3"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: cal3.clone(),
-                name: String::from("Task A3"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&cal3),
+        initial_state: LocatedState::Local(ItemState {
+            calendar: cal3.clone(),
+            name: String::from("Task A3"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: cal3.clone(),
+            name: String::from("Task A3"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&cal4),
-            initial_state: LocatedState::Local( ItemState{
-                calendar: cal4.clone(),
-                name: String::from("Task A4"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: cal4.clone(),
-                name: String::from("Task A4"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&cal4),
+        initial_state: LocatedState::Local(ItemState {
+            calendar: cal4.clone(),
+            name: String::from("Task A4"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: cal4.clone(),
+            name: String::from("Task A4"),
+            completed: false,
+        }),
+    });
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&cal3),
-            initial_state: LocatedState::Local( ItemState{
-                calendar: cal3.clone(),
-                name: String::from("Task B3"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: cal3.clone(),
-                name: String::from("Task B3"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&cal3),
+        initial_state: LocatedState::Local(ItemState {
+            calendar: cal3.clone(),
+            name: String::from("Task B3"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: cal3.clone(),
+            name: String::from("Task B3"),
+            completed: false,
+        }),
+    });
 
     tasks
 }
-
 
 /// This scenario tests a task added and deleted before a sync happens
 pub fn scenarii_transient_task() -> Vec<ItemScenario> {
@@ -549,80 +523,100 @@ pub fn scenarii_transient_task() -> Vec<ItemScenario> {
 
     let cal = Url::from("https://some.calend.ar/transient/".parse().unwrap());
 
-    tasks.push(
-        ItemScenario {
-            url: random_url(&cal),
-            initial_state: LocatedState::Local( ItemState{
-                calendar: cal.clone(),
-                name: String::from("A task, so that the calendar actually exists"),
-                completed: false,
-            }),
-            local_changes_to_apply: Vec::new(),
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::BothSynced( ItemState{
-                calendar: cal.clone(),
-                name: String::from("A task, so that the calendar actually exists"),
-                completed: false,
-            }),
-        }
-    );
+    tasks.push(ItemScenario {
+        url: random_url(&cal),
+        initial_state: LocatedState::Local(ItemState {
+            calendar: cal.clone(),
+            name: String::from("A task, so that the calendar actually exists"),
+            completed: false,
+        }),
+        local_changes_to_apply: Vec::new(),
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::BothSynced(ItemState {
+            calendar: cal.clone(),
+            name: String::from("A task, so that the calendar actually exists"),
+            completed: false,
+        }),
+    });
 
     let url_transient = random_url(&cal);
-    tasks.push(
-        ItemScenario {
-            url: url_transient.clone(),
-            initial_state: LocatedState::None,
-            local_changes_to_apply: vec![
-                ChangeToApply::Create(cal, Item::Task(
-                    Task::new_with_parameters(
-                        String::from("A transient task that will be deleted before the sync"),
-                        url_transient.to_string(), url_transient,
-                        CompletionStatus::Uncompleted,
-                        SyncStatus::NotSynced, Some(Utc::now()), Utc::now(),
-                        "prod_id".to_string(), Vec::new() )
+    tasks.push(ItemScenario {
+        url: url_transient.clone(),
+        initial_state: LocatedState::None,
+        local_changes_to_apply: vec![
+            ChangeToApply::Create(
+                cal,
+                Item::Task(Task::new_with_parameters(
+                    String::from("A transient task that will be deleted before the sync"),
+                    url_transient.to_string(),
+                    url_transient,
+                    CompletionStatus::Uncompleted,
+                    SyncStatus::NotSynced,
+                    Some(Utc::now()),
+                    Utc::now(),
+                    "prod_id".to_string(),
+                    Vec::new(),
                 )),
-
-                ChangeToApply::Rename(String::from("A new name")),
-                ChangeToApply::SetCompletion(true),
-                ChangeToApply::Remove,
-            ],
-            remote_changes_to_apply: Vec::new(),
-            after_sync: LocatedState::None,
-        }
-    );
+            ),
+            ChangeToApply::Rename(String::from("A new name")),
+            ChangeToApply::SetCompletion(true),
+            ChangeToApply::Remove,
+        ],
+        remote_changes_to_apply: Vec::new(),
+        after_sync: LocatedState::None,
+    });
 
     tasks
 }
 
-
 /// Build a `Provider` that contains the data (defined in the given scenarii) before sync
-pub async fn populate_test_provider_before_sync(scenarii: &[ItemScenario], mock_behaviour: Arc<Mutex<MockBehaviour>>) -> Provider<Cache, CachedCalendar, Cache, CachedCalendar> {
+pub async fn populate_test_provider_before_sync(
+    scenarii: &[ItemScenario],
+    mock_behaviour: Arc<Mutex<MockBehaviour>>,
+) -> Provider<Cache, CachedCalendar, Cache, CachedCalendar> {
     let mut provider = populate_test_provider(scenarii, mock_behaviour, false).await;
     apply_changes_on_provider(&mut provider, scenarii).await;
     provider
 }
 
 /// Build a `Provider` that contains the data (defined in the given scenarii) after sync
-pub async fn populate_test_provider_after_sync(scenarii: &[ItemScenario], mock_behaviour: Arc<Mutex<MockBehaviour>>) -> Provider<Cache, CachedCalendar, Cache, CachedCalendar> {
+pub async fn populate_test_provider_after_sync(
+    scenarii: &[ItemScenario],
+    mock_behaviour: Arc<Mutex<MockBehaviour>>,
+) -> Provider<Cache, CachedCalendar, Cache, CachedCalendar> {
     populate_test_provider(scenarii, mock_behaviour, true).await
 }
 
-async fn populate_test_provider(scenarii: &[ItemScenario], mock_behaviour: Arc<Mutex<MockBehaviour>>, populate_for_final_state: bool) -> Provider<Cache, CachedCalendar, Cache, CachedCalendar> {
+async fn populate_test_provider(
+    scenarii: &[ItemScenario],
+    mock_behaviour: Arc<Mutex<MockBehaviour>>,
+    populate_for_final_state: bool,
+) -> Provider<Cache, CachedCalendar, Cache, CachedCalendar> {
     let mut local = Cache::new(&PathBuf::from(String::from("test_cache/local/")));
     let mut remote = Cache::new(&PathBuf::from(String::from("test_cache/remote/")));
     remote.set_mock_behaviour(Some(mock_behaviour));
 
     // Create the initial state, as if we synced both sources in a given state
     for item in scenarii {
-        let required_state = if populate_for_final_state { &item.after_sync } else { &item.initial_state };
+        let required_state = if populate_for_final_state {
+            &item.after_sync
+        } else {
+            &item.initial_state
+        };
         let (state, sync_status) = match required_state {
             LocatedState::None => continue,
             LocatedState::Local(s) => {
-                assert!(populate_for_final_state == false, "You are not supposed to expect an item in this state after sync");
+                assert!(
+                    populate_for_final_state == false,
+                    "You are not supposed to expect an item in this state after sync"
+                );
                 (s, SyncStatus::NotSynced)
-            },
+            }
             LocatedState::Remote(s) => {
-                assert!(populate_for_final_state == false, "You are not supposed to expect an item in this state after sync");
+                assert!(
+                    populate_for_final_state == false,
+                    "You are not supposed to expect an item in this state after sync"
+                );
                 (s, SyncStatus::random_synced())
             }
             LocatedState::BothSynced(s) => (s, SyncStatus::random_synced()),
@@ -634,37 +628,68 @@ async fn populate_test_provider(scenarii: &[ItemScenario], mock_behaviour: Arc<M
             true => CompletionStatus::Completed(Some(now)),
         };
 
-        let new_item = Item::Task(
-            Task::new_with_parameters(
-                state.name.clone(),
-                item.url.to_string(),
-                item.url.clone(),
-                completion_status,
-                sync_status,
-                Some(now),
-                now,
-                "prod_id".to_string(), Vec::new(),
-            ));
+        let new_item = Item::Task(Task::new_with_parameters(
+            state.name.clone(),
+            item.url.to_string(),
+            item.url.clone(),
+            completion_status,
+            sync_status,
+            Some(now),
+            now,
+            "prod_id".to_string(),
+            Vec::new(),
+        ));
 
         match required_state {
             LocatedState::None => panic!("Should not happen, we've continued already"),
             LocatedState::Local(s) => {
-                get_or_insert_calendar(&mut local,  &s.calendar).await.unwrap().lock().unwrap().add_item(new_item).await.unwrap();
-            },
+                get_or_insert_calendar(&mut local, &s.calendar)
+                    .await
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .add_item(new_item)
+                    .await
+                    .unwrap();
+            }
             LocatedState::Remote(s) => {
-                get_or_insert_calendar(&mut remote, &s.calendar).await.unwrap().lock().unwrap().add_item(new_item).await.unwrap();
-            },
+                get_or_insert_calendar(&mut remote, &s.calendar)
+                    .await
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .add_item(new_item)
+                    .await
+                    .unwrap();
+            }
             LocatedState::BothSynced(s) => {
-                get_or_insert_calendar(&mut local,  &s.calendar).await.unwrap().lock().unwrap().add_item(new_item.clone()).await.unwrap();
-                get_or_insert_calendar(&mut remote, &s.calendar).await.unwrap().lock().unwrap().add_item(new_item).await.unwrap();
-            },
+                get_or_insert_calendar(&mut local, &s.calendar)
+                    .await
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .add_item(new_item.clone())
+                    .await
+                    .unwrap();
+                get_or_insert_calendar(&mut remote, &s.calendar)
+                    .await
+                    .unwrap()
+                    .lock()
+                    .unwrap()
+                    .add_item(new_item)
+                    .await
+                    .unwrap();
+            }
         }
     }
     Provider::new(remote, local)
 }
 
 /// Apply `local_changes_to_apply` and `remote_changes_to_apply` to a provider that contains data before sync
-async fn apply_changes_on_provider(provider: &mut Provider<Cache, CachedCalendar, Cache, CachedCalendar>, scenarii: &[ItemScenario]) {
+async fn apply_changes_on_provider(
+    provider: &mut Provider<Cache, CachedCalendar, Cache, CachedCalendar>,
+    scenarii: &[ItemScenario],
+) {
     // Apply changes to each item
     for item in scenarii {
         let initial_calendar_url = match &item.initial_state {
@@ -676,19 +701,38 @@ async fn apply_changes_on_provider(provider: &mut Provider<Cache, CachedCalendar
 
         let mut calendar_url = initial_calendar_url.clone();
         for local_change in &item.local_changes_to_apply {
-            calendar_url = Some(apply_change(provider.local(), calendar_url, &item.url, local_change, false).await);
+            calendar_url = Some(
+                apply_change(
+                    provider.local(),
+                    calendar_url,
+                    &item.url,
+                    local_change,
+                    false,
+                )
+                .await,
+            );
         }
 
         let mut calendar_url = initial_calendar_url;
         for remote_change in &item.remote_changes_to_apply {
-            calendar_url = Some(apply_change(provider.remote(), calendar_url, &item.url, remote_change, true).await);
+            calendar_url = Some(
+                apply_change(
+                    provider.remote(),
+                    calendar_url,
+                    &item.url,
+                    remote_change,
+                    true,
+                )
+                .await,
+            );
         }
     }
 }
 
-async fn get_or_insert_calendar(source: &mut Cache, url: &Url)
-    -> Result<Arc<Mutex<CachedCalendar>>, Box<dyn Error>>
-{
+async fn get_or_insert_calendar(
+    source: &mut Cache,
+    url: &Url,
+) -> Result<Arc<Mutex<CachedCalendar>>, Box<dyn Error>> {
     match source.get_calendar(url).await {
         Some(cal) => Ok(cal),
         None => {
@@ -696,18 +740,26 @@ async fn get_or_insert_calendar(source: &mut Cache, url: &Url)
             let supported_components = SupportedComponents::TODO;
             let color = csscolorparser::parse("#ff8000").unwrap(); // TODO: we should rather have specific colors, depending on the calendars
 
-            source.create_calendar(
-                url.clone(),
-                new_name.to_string(),
-                supported_components,
-                Some(color),
-            ).await
+            source
+                .create_calendar(
+                    url.clone(),
+                    new_name.to_string(),
+                    supported_components,
+                    Some(color),
+                )
+                .await
         }
     }
 }
 
 /// Apply a single change on a given source, and returns the calendar URL that was modified
-async fn apply_change<S, C>(source: &S, calendar_url: Option<Url>, item_url: &Url, change: &ChangeToApply, is_remote: bool) -> Url
+async fn apply_change<S, C>(
+    source: &S,
+    calendar_url: Option<Url>,
+    item_url: &Url,
+    change: &ChangeToApply,
+    is_remote: bool,
+) -> Url
 where
     S: CalDavSource<C>,
     C: CompleteCalendar + DavCalendar, // in this test, we're using a calendar that mocks both kinds
@@ -716,21 +768,28 @@ where
         Some(cal) => {
             apply_changes_on_an_existing_item(source, &cal, item_url, change, is_remote).await;
             cal
-        },
-        None => {
-            create_test_item(source, change).await
-        },
+        }
+        None => create_test_item(source, change).await,
     }
 }
 
-async fn apply_changes_on_an_existing_item<S, C>(source: &S, calendar_url: &Url, item_url: &Url, change: &ChangeToApply, is_remote: bool)
-where
+async fn apply_changes_on_an_existing_item<S, C>(
+    source: &S,
+    calendar_url: &Url,
+    item_url: &Url,
+    change: &ChangeToApply,
+    is_remote: bool,
+) where
     S: CalDavSource<C>,
     C: CompleteCalendar + DavCalendar, // in this test, we're using a calendar that mocks both kinds
 {
     let cal = source.get_calendar(calendar_url).await.unwrap();
     let mut cal = cal.lock().unwrap();
-    let task = cal.get_item_by_url_mut(item_url).await.unwrap().unwrap_task_mut();
+    let task = cal
+        .get_item_by_url_mut(item_url)
+        .await
+        .unwrap()
+        .unwrap_task_mut();
 
     match change {
         ChangeToApply::Rename(new_name) => {
@@ -739,7 +798,7 @@ where
             } else {
                 task.set_name(new_name.clone());
             }
-        },
+        }
         ChangeToApply::SetCompletion(new_status) => {
             let completion_status = match new_status {
                 false => CompletionStatus::Uncompleted,
@@ -750,16 +809,16 @@ where
             } else {
                 task.set_completion_status(completion_status);
             }
-        },
+        }
         ChangeToApply::Remove => {
             match is_remote {
                 false => cal.mark_for_deletion(item_url).await.unwrap(),
                 true => cal.delete_item(item_url).await.unwrap(),
             };
-        },
+        }
         ChangeToApply::Create(_calendar_url, _item) => {
             panic!("This function only handles already existing items");
-        },
+        }
     }
 }
 
@@ -770,15 +829,13 @@ where
     C: CompleteCalendar + DavCalendar, // in this test, we're using a calendar that mocks both kinds
 {
     match change {
-        ChangeToApply::Rename(_) |
-        ChangeToApply::SetCompletion(_) |
-        ChangeToApply::Remove => {
+        ChangeToApply::Rename(_) | ChangeToApply::SetCompletion(_) | ChangeToApply::Remove => {
             panic!("This function only creates items that do not exist yet");
         }
         ChangeToApply::Create(calendar_url, item) => {
             let cal = source.get_calendar(calendar_url).await.unwrap();
             cal.lock().unwrap().add_item(item.clone()).await.unwrap();
             calendar_url.clone()
-        },
+        }
     }
 }

--- a/tests/scenarii.rs
+++ b/tests/scenarii.rs
@@ -9,7 +9,6 @@
 #![cfg(feature = "local_calendar_mocks_remote_calendars")]
 
 use kitchen_fridge::error::KFResult;
-use std::error::Error;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use url::Url;

--- a/tests/scenarii.rs
+++ b/tests/scenarii.rs
@@ -8,6 +8,7 @@
 //! This module can also check the sources after a sync contain the actual data we expect
 #![cfg(feature = "local_calendar_mocks_remote_calendars")]
 
+use kitchen_fridge::error::KFResult;
 use std::error::Error;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -732,7 +733,7 @@ async fn apply_changes_on_provider(
 async fn get_or_insert_calendar(
     source: &mut Cache,
     url: &Url,
-) -> Result<Arc<Mutex<CachedCalendar>>, Box<dyn Error>> {
+) -> KFResult<Arc<Mutex<CachedCalendar>>> {
     match source.get_calendar(url).await {
         Some(cal) => Ok(cal),
         None => {

--- a/tests/scenarii.rs
+++ b/tests/scenarii.rs
@@ -86,9 +86,9 @@ pub struct ItemScenario {
 pub fn scenarii_basic() -> Vec<ItemScenario> {
     let mut tasks = Vec::new();
 
-    let first_cal = Url::from("https://some.calend.ar/calendar-1/".parse().unwrap());
-    let second_cal = Url::from("https://some.calend.ar/calendar-2/".parse().unwrap());
-    let third_cal = Url::from("https://some.calend.ar/calendar-3/".parse().unwrap());
+    let first_cal = "https://some.calend.ar/calendar-1/".parse().unwrap();
+    let second_cal = "https://some.calend.ar/calendar-2/".parse().unwrap();
+    let third_cal = "https://some.calend.ar/calendar-3/".parse().unwrap();
 
     tasks.push(ItemScenario {
         url: random_url(&first_cal),
@@ -405,8 +405,8 @@ pub fn scenarii_basic() -> Vec<ItemScenario> {
 pub fn scenarii_first_sync_to_local() -> Vec<ItemScenario> {
     let mut tasks = Vec::new();
 
-    let cal1 = Url::from("https://some.calend.ar/first/".parse().unwrap());
-    let cal2 = Url::from("https://some.calend.ar/second/".parse().unwrap());
+    let cal1 = "https://some.calend.ar/first/".parse().unwrap();
+    let cal2 = "https://some.calend.ar/second/".parse().unwrap();
 
     tasks.push(ItemScenario {
         url: random_url(&cal1),
@@ -463,8 +463,8 @@ pub fn scenarii_first_sync_to_local() -> Vec<ItemScenario> {
 pub fn scenarii_first_sync_to_server() -> Vec<ItemScenario> {
     let mut tasks = Vec::new();
 
-    let cal3 = Url::from("https://some.calend.ar/third/".parse().unwrap());
-    let cal4 = Url::from("https://some.calend.ar/fourth/".parse().unwrap());
+    let cal3 = "https://some.calend.ar/third/".parse().unwrap();
+    let cal4 = "https://some.calend.ar/fourth/".parse().unwrap();
 
     tasks.push(ItemScenario {
         url: random_url(&cal3),
@@ -521,7 +521,7 @@ pub fn scenarii_first_sync_to_server() -> Vec<ItemScenario> {
 pub fn scenarii_transient_task() -> Vec<ItemScenario> {
     let mut tasks = Vec::new();
 
-    let cal = Url::from("https://some.calend.ar/transient/".parse().unwrap());
+    let cal = "https://some.calend.ar/transient/".parse().unwrap();
 
     tasks.push(ItemScenario {
         url: random_url(&cal),
@@ -607,14 +607,14 @@ async fn populate_test_provider(
             LocatedState::None => continue,
             LocatedState::Local(s) => {
                 assert!(
-                    populate_for_final_state == false,
+                    !populate_for_final_state,
                     "You are not supposed to expect an item in this state after sync"
                 );
                 (s, SyncStatus::NotSynced)
             }
             LocatedState::Remote(s) => {
                 assert!(
-                    populate_for_final_state == false,
+                    !populate_for_final_state,
                     "You are not supposed to expect an item in this state after sync"
                 );
                 (s, SyncStatus::random_synced())

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -6,8 +6,6 @@ use std::sync::{Arc, Mutex};
 #[cfg(feature = "local_calendar_mocks_remote_calendars")]
 use kitchen_fridge::mock_behaviour::MockBehaviour;
 
-
-
 /// A test that simulates a regular synchronisation between a local cache and a server.
 /// Note that this uses a second cache to "mock" a server.
 struct TestFlavour {
@@ -19,22 +17,54 @@ struct TestFlavour {
 
 #[cfg(not(feature = "local_calendar_mocks_remote_calendars"))]
 impl TestFlavour {
-    pub fn normal() -> Self { Self{} }
-    pub fn first_sync_to_local() -> Self { Self{} }
-    pub fn first_sync_to_server() -> Self { Self{} }
-    pub fn transient_task() -> Self { Self{} }
-    pub fn normal_with_errors1() -> Self { Self{} }
-    pub fn normal_with_errors2() -> Self { Self{} }
-    pub fn normal_with_errors3() -> Self { Self{} }
-    pub fn normal_with_errors4() -> Self { Self{} }
-    pub fn normal_with_errors5() -> Self { Self{} }
-    pub fn normal_with_errors6() -> Self { Self{} }
-    pub fn normal_with_errors7() -> Self { Self{} }
-    pub fn normal_with_errors8() -> Self { Self{} }
-    pub fn normal_with_errors9() -> Self { Self{} }
-    pub fn normal_with_errors10() -> Self { Self{} }
-    pub fn normal_with_errors11() -> Self { Self{} }
-    pub fn normal_with_errors12() -> Self { Self{} }
+    pub fn normal() -> Self {
+        Self {}
+    }
+    pub fn first_sync_to_local() -> Self {
+        Self {}
+    }
+    pub fn first_sync_to_server() -> Self {
+        Self {}
+    }
+    pub fn transient_task() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors1() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors2() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors3() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors4() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors5() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors6() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors7() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors8() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors9() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors10() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors11() -> Self {
+        Self {}
+    }
+    pub fn normal_with_errors12() -> Self {
+        Self {}
+    }
 
     pub async fn run(&self, _max_attempts: u32) {
         panic!("WARNING: This test required the \"integration_tests\" Cargo feature");
@@ -81,9 +111,9 @@ impl TestFlavour {
     pub fn normal_with_errors2() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                get_calendars_behaviour: (0,1),
-                create_calendar_behaviour: (2,2),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                get_calendars_behaviour: (0, 1),
+                create_calendar_behaviour: (2, 2),
                 ..MockBehaviour::default()
             })),
         }
@@ -92,9 +122,9 @@ impl TestFlavour {
     pub fn normal_with_errors3() -> Self {
         Self {
             scenarii: scenarii::scenarii_first_sync_to_server(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                get_calendars_behaviour: (1,6),
-                create_calendar_behaviour: (0,1),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                get_calendars_behaviour: (1, 6),
+                create_calendar_behaviour: (0, 1),
                 ..MockBehaviour::default()
             })),
         }
@@ -103,8 +133,8 @@ impl TestFlavour {
     pub fn normal_with_errors4() -> Self {
         Self {
             scenarii: scenarii::scenarii_first_sync_to_server(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                add_item_behaviour: (1,3),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                add_item_behaviour: (1, 3),
                 ..MockBehaviour::default()
             })),
         }
@@ -113,8 +143,8 @@ impl TestFlavour {
     pub fn normal_with_errors5() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                get_item_version_tags_behaviour: (0,1),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                get_item_version_tags_behaviour: (0, 1),
                 ..MockBehaviour::default()
             })),
         }
@@ -123,8 +153,8 @@ impl TestFlavour {
     pub fn normal_with_errors6() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                get_item_by_url_behaviour: (3,2),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                get_item_by_url_behaviour: (3, 2),
                 ..MockBehaviour::default()
             })),
         }
@@ -133,8 +163,8 @@ impl TestFlavour {
     pub fn normal_with_errors7() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                delete_item_behaviour: (0,2),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                delete_item_behaviour: (0, 2),
                 ..MockBehaviour::default()
             })),
         }
@@ -143,9 +173,9 @@ impl TestFlavour {
     pub fn normal_with_errors8() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                add_item_behaviour: (2,3),
-                get_item_by_url_behaviour: (1,12),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                add_item_behaviour: (2, 3),
+                get_item_by_url_behaviour: (1, 12),
                 ..MockBehaviour::default()
             })),
         }
@@ -154,9 +184,9 @@ impl TestFlavour {
     pub fn normal_with_errors9() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                get_calendars_behaviour: (0,8),
-                delete_item_behaviour: (1,1),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                get_calendars_behaviour: (0, 8),
+                delete_item_behaviour: (1, 1),
                 ..MockBehaviour::default()
             })),
         }
@@ -165,11 +195,11 @@ impl TestFlavour {
     pub fn normal_with_errors10() -> Self {
         Self {
             scenarii: scenarii::scenarii_first_sync_to_server(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                get_calendars_behaviour: (0,8),
-                delete_item_behaviour: (1,1),
-                create_calendar_behaviour: (1,4),
-                get_item_version_tags_behaviour: (3,1),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                get_calendars_behaviour: (0, 8),
+                delete_item_behaviour: (1, 1),
+                create_calendar_behaviour: (1, 4),
+                get_item_version_tags_behaviour: (3, 1),
                 ..MockBehaviour::default()
             })),
         }
@@ -178,12 +208,12 @@ impl TestFlavour {
     pub fn normal_with_errors11() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                get_calendars_behaviour: (0,8),
-                delete_item_behaviour: (1,1),
-                create_calendar_behaviour: (1,4),
-                get_item_version_tags_behaviour: (3,1),
-                get_item_by_url_behaviour: (0,41),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                get_calendars_behaviour: (0, 8),
+                delete_item_behaviour: (1, 1),
+                create_calendar_behaviour: (1, 4),
+                get_item_version_tags_behaviour: (3, 1),
+                get_item_by_url_behaviour: (0, 41),
                 ..MockBehaviour::default()
             })),
         }
@@ -192,18 +222,21 @@ impl TestFlavour {
     pub fn normal_with_errors12() -> Self {
         Self {
             scenarii: scenarii::scenarii_basic(),
-            mock_behaviour: Arc::new(Mutex::new(MockBehaviour{
-                update_item_behaviour: (0,3),
+            mock_behaviour: Arc::new(Mutex::new(MockBehaviour {
+                update_item_behaviour: (0, 3),
                 ..MockBehaviour::default()
             })),
         }
     }
 
-
     pub async fn run(&self, max_attempts: u32) {
         self.mock_behaviour.lock().unwrap().suspend();
 
-        let mut provider = scenarii::populate_test_provider_before_sync(&self.scenarii, Arc::clone(&self.mock_behaviour)).await;
+        let mut provider = scenarii::populate_test_provider_before_sync(
+            &self.scenarii,
+            Arc::clone(&self.mock_behaviour),
+        )
+        .await;
         print_provider(&provider, "before sync").await;
 
         self.mock_behaviour.lock().unwrap().resume();
@@ -211,7 +244,7 @@ impl TestFlavour {
             println!("\nSyncing...\n");
             if provider.sync().await == true {
                 println!("Sync complete after {} attempts (multiple attempts are due to forced errors in mocked behaviour)", attempt+1);
-                break
+                break;
             }
         }
         self.mock_behaviour.lock().unwrap().suspend();
@@ -219,23 +252,45 @@ impl TestFlavour {
         print_provider(&provider, "after sync").await;
 
         // Check the contents of both sources are the same after sync
-        assert!(provider.remote().has_same_observable_content_as(provider.local()).await.unwrap());
+        assert!(provider
+            .remote()
+            .has_same_observable_content_as(provider.local())
+            .await
+            .unwrap());
 
         // But also explicitely check that every item is expected
-        let expected_provider = scenarii::populate_test_provider_after_sync(&self.scenarii, Arc::clone(&self.mock_behaviour)).await;
+        let expected_provider = scenarii::populate_test_provider_after_sync(
+            &self.scenarii,
+            Arc::clone(&self.mock_behaviour),
+        )
+        .await;
 
-        assert!(provider.local() .has_same_observable_content_as(expected_provider.local() ).await.unwrap());
-        assert!(provider.remote().has_same_observable_content_as(expected_provider.remote()).await.unwrap());
+        assert!(provider
+            .local()
+            .has_same_observable_content_as(expected_provider.local())
+            .await
+            .unwrap());
+        assert!(provider
+            .remote()
+            .has_same_observable_content_as(expected_provider.remote())
+            .await
+            .unwrap());
 
         // Perform a second sync, even if no change has happened, just to check
         println!("Syncing again");
         provider.sync().await;
-        assert!(provider.local() .has_same_observable_content_as(expected_provider.local() ).await.unwrap());
-        assert!(provider.remote().has_same_observable_content_as(expected_provider.remote()).await.unwrap());
+        assert!(provider
+            .local()
+            .has_same_observable_content_as(expected_provider.local())
+            .await
+            .unwrap());
+        assert!(provider
+            .remote()
+            .has_same_observable_content_as(expected_provider.remote())
+            .await
+            .unwrap());
     }
 }
-
-
 
 async fn run_flavour(flavour: TestFlavour, max_attempts: u32) {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -243,112 +298,114 @@ async fn run_flavour(flavour: TestFlavour, max_attempts: u32) {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_regular_sync() {
     run_flavour(TestFlavour::normal(), 1).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_sync_empty_initial_local() {
     run_flavour(TestFlavour::first_sync_to_local(), 1).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_sync_empty_initial_server() {
     run_flavour(TestFlavour::first_sync_to_server(), 1).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_sync_transient_task() {
     run_flavour(TestFlavour::transient_task(), 1).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync1() {
     run_flavour(TestFlavour::normal_with_errors1(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync2() {
     run_flavour(TestFlavour::normal_with_errors2(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync3() {
     run_flavour(TestFlavour::normal_with_errors3(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync4() {
     run_flavour(TestFlavour::normal_with_errors4(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync5() {
     run_flavour(TestFlavour::normal_with_errors5(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync6() {
     run_flavour(TestFlavour::normal_with_errors6(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync7() {
     run_flavour(TestFlavour::normal_with_errors7(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync8() {
     run_flavour(TestFlavour::normal_with_errors8(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync9() {
     run_flavour(TestFlavour::normal_with_errors9(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync10() {
     run_flavour(TestFlavour::normal_with_errors10(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync11() {
     run_flavour(TestFlavour::normal_with_errors11(), 100).await;
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature="integration_tests"), ignore)]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
 async fn test_errors_in_regular_sync12() {
     run_flavour(TestFlavour::normal_with_errors12(), 100).await;
 }
 
 #[cfg(feature = "integration_tests")]
-use kitchen_fridge::{traits::CalDavSource,
-               provider::Provider,
-               cache::Cache,
-               calendar::cached_calendar::CachedCalendar,
+use kitchen_fridge::{
+    cache::Cache, calendar::cached_calendar::CachedCalendar, provider::Provider,
+    traits::CalDavSource,
 };
 
 /// Print the contents of the provider. This is usually used for debugging
 #[allow(dead_code)]
 #[cfg(feature = "integration_tests")]
-async fn print_provider(provider: &Provider<Cache, CachedCalendar, Cache, CachedCalendar>, title: &str) {
+async fn print_provider(
+    provider: &Provider<Cache, CachedCalendar, Cache, CachedCalendar>,
+    title: &str,
+) {
     let cals_server = provider.remote().get_calendars().await.unwrap();
     println!("----Server, {}-------", title);
     kitchen_fridge::utils::print_calendar_list(&cals_server).await;

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -242,7 +242,7 @@ impl TestFlavour {
         self.mock_behaviour.lock().unwrap().resume();
         for attempt in 0..max_attempts {
             println!("\nSyncing...\n");
-            if provider.sync().await == true {
+            if provider.sync().await {
                 println!("Sync complete after {} attempts (multiple attempts are due to forced errors in mocked behaviour)", attempt+1);
                 break;
             }


### PR DESCRIPTION
Move to a static error type using thiserror; avoids Box<dyn Error> and makes error handling clearer / more explicit.

Builds on the lintfix2 branch, #6.